### PR TITLE
kubeconfig src bind for krknctl command

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -15,7 +15,7 @@ RUN node -v && \
 
 WORKDIR /usr/src/chaos-dashboard
 
-ENV CONTAINER_BUILD=true
+ENV EXTERNAL_CONTAINER_BUILD=true
 # Install app dependencies
 # A wildcard is used to ensure both package.json AND package-lock.json are copied
 # where available (npm@5+)

--- a/containers/podman-run.sh
+++ b/containers/podman-run.sh
@@ -6,6 +6,7 @@ IMAGE_NAME="chaos-dashboard:latest"
 CONTAINER_NAME="chaos-dashboard-app"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CHAOS_ASSETS="$ROOT_DIR/src/assets"
+KUBECONFIG_PATH="${KUBECONFIG_PATH:-$CHAOS_ASSETS/kubeconfig}"
 
 # krkn-hub images are commonly amd64-only; default to amd64 for cross-machine compatibility.
 ARCH="$(uname -m)"
@@ -69,8 +70,11 @@ podman run -d \
   "${ENV_PLATFORM_ARGS[@]}" \
   ${GROUP_ARGS[@]+"${GROUP_ARGS[@]}"} \
   -e "CHAOS_ASSETS=$CHAOS_ASSETS" \
+  -e "KUBECONFIG_PATH=$KUBECONFIG_PATH" \
+  -e "EXTERNAL_CONTAINER_BUILD=false" \
   --security-opt label=disable \
   -v "$CHAOS_ASSETS:/usr/src/chaos-dashboard/src/assets:z" \
+  -v "$KUBECONFIG_PATH:/usr/src/chaos-dashboard/src/assets/kubeconfig:z" \
   -v "$ROOT_DIR/database:/usr/src/chaos-dashboard/database:z" \
   -v "$VM_SOCK_PATH:/run/podman/podman.sock:z" \
   -p 3000:3000 \

--- a/package-lock.json
+++ b/package-lock.json
@@ -5954,7 +5954,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/server/index.js
+++ b/server/index.js
@@ -45,6 +45,33 @@ app.use(express.json());
 
 /* Set path to upload config file */
 const uploadFilePath = path.resolve(__dirname, "../", "src/assets");
+
+function getChaosAssetsRoot() {
+  return (process.env.CHAOS_ASSETS || "").trim().replace(/\/+$/, "");
+}
+
+function getUploadKubeconfigPath() {
+  return path.join(uploadFilePath, "kubeconfig");
+}
+
+function getOrchestratorKubeconfigPath() {
+  return path.join(getChaosAssetsRoot(), "kubeconfig");
+}
+
+/**
+ * Local: always the uploaded/mounted file under `src/assets/kubeconfig`.
+ * External container: uploaded file (overwrites mount) when `isFileUpload`; otherwise `CHAOS_ASSETS/kubeconfig`.
+ */
+function resolveKubeconfigPathForRequest(isFileUpload) {
+  if ((process.env.EXTERNAL_CONTAINER_BUILD || "").trim() === "true") {
+    if (isFileUpload) {
+      return getUploadKubeconfigPath();
+    }
+    return getOrchestratorKubeconfigPath();
+  }
+  return getUploadKubeconfigPath();
+}
+
 let myInterval;
 
 chmodr(uploadFilePath, 0o777, (err) => {
@@ -55,7 +82,7 @@ chmodr(uploadFilePath, 0o777, (err) => {
   }
 });
 let PODMAN = "";
-if (process.env.CONTAINER_BUILD) {
+if (process.env.EXTERNAL_CONTAINER_BUILD) {
   PODMAN = "podman-remote";
 } else {
   PODMAN = "podman";
@@ -74,7 +101,7 @@ const PODMAN_RUN_PLATFORM_PREFIX = getPodmanRunPlatformPrefix();
 
 // Validates the podman socket before starting a container instance
 if (
-  process.env.CONTAINER_BUILD &&
+  process.env.EXTERNAL_CONTAINER_BUILD &&
   !fs.existsSync("/run/podman/podman.sock") &&
   !process.env.CONTAINER_HOST
 ) {
@@ -84,7 +111,7 @@ if (
       "or set CONTAINER_HOST for a TCP API. See containers/podman-run.sh."
   );
 } else if (
-  process.env.CONTAINER_BUILD &&
+  process.env.EXTERNAL_CONTAINER_BUILD &&
   fs.existsSync("/run/podman/podman.sock") &&
   !process.env.CONTAINER_HOST
 ) {
@@ -103,39 +130,18 @@ if (
 
 app.post("/start-kraken/", (req, res) => {
   const scenario = req.body.params.scenarioChecked;
-  let kubeConfigPath = "";
+  const isFileUpload = Boolean(req.body.params?.isFileUpload);
 
-  if (process.env.CONTAINER_BUILD) {
-    kubeConfigPath = `${process.env.CHAOS_ASSETS}/kubeconfig`;
-  } else {
-    kubeConfigPath = req.body.params.isFileUpload
-      ? `${uploadFilePath}/kubeconfig`
-      : req.body.params.kubeconfigPath;
-  }
-
-  if (!kubeConfigPath || kubeConfigPath.startsWith("undefined/")) {
+  const kubeConfigFileLocation = resolveKubeconfigPathForRequest(isFileUpload);
+  if (!fs.existsSync(kubeConfigFileLocation)) {
     return res.status(400).json({
-      message:
-        "Invalid kubeconfig path. Set CHAOS_ASSETS in container mode or provide kubeconfigPath/upload a file.",
+      message: `kubeconfig not found at: ${kubeConfigFileLocation}. If the file exists elsewhere in the image, CHAOS_ASSETS is wrong for this image.`,
       status: "failed",
     });
   }
 
-  if (process.env.CONTAINER_BUILD) {
-    const uploadedKubeconfigPath = `${uploadFilePath}/kubeconfig`;
-    if (!fs.existsSync(uploadedKubeconfigPath)) {
-      return res.status(400).json({
-        message:
-          "kubeconfig not found in mounted assets. Upload kubeconfig or ensure src/assets/kubeconfig exists.",
-        status: "failed",
-      });
-    }
-  } else if (!fs.existsSync(kubeConfigPath)) {
-    return res.status(400).json({
-      message: `kubeconfig not found at: ${kubeConfigPath}`,
-      status: "failed",
-    });
-  }
+  // kubeconfig path: KUBECONFIG_PATH when set (e.g. host path for podman-remote) and fallback to the file location above when on npm run dev
+  const kubeConfigPath = (process.env.KUBECONFIG_PATH || "").trim() || kubeConfigFileLocation;
 
   let command = "";
   switch (scenario) {
@@ -167,10 +173,10 @@ app.post("/start-kraken/", (req, res) => {
       command = `echo 'No scenario selected'`;
   }
   console.log(command);
+  // Podman prints pull/progress to stderr; a non-empty stderr is normal. Only treat
+  // non-zero exit (err) as failure. Use a large buffer so first-time image pulls don't
+  // hit ERR_CHILD_PROCESS_STDIO_MAXBUFFER.
   child_process.exec(command, EXEC_LARGE_MAX_BUFFER, (err, stdout, stderr) => {
-    if (stderr && !err) {
-      console.log("[start-kraken] podman stderr (informational):", stripAnsi(stderr).slice(0, 2000));
-    }
     if (!err) {
       res.status(200).json({
         message: "Successfully created the container!",
@@ -178,6 +184,9 @@ app.post("/start-kraken/", (req, res) => {
         status: "200",
       });
       myInterval = setInterval(() => myFunc(req.body.params.name), 1000 * 9);
+      if (stderr) {
+        console.log("[start-kraken] podman stderr (informational):", stripAnsi(stderr).slice(0, 2000));
+      }
       return;
     }
     const detail = [stderr, stdout].filter(Boolean).join("\n") || err.message;
@@ -255,6 +264,17 @@ app.get("/removePod", (req, res) => {
       });
     }
     res.end();
+  });
+});
+
+app.get("/getKubeconfigContext", (req, res) => {
+  const external = (process.env.EXTERNAL_CONTAINER_BUILD || "").trim() === "true";
+  res.json({
+    // Upload is always available (including external container: optional override of orchestrator kubeconfig).
+    externallyBound: false,
+    pathDisplay: external
+      ? (process.env.KUBECONFIG_PATH || "").trim() || getOrchestratorKubeconfigPath()
+      : "",
   });
 });
 

--- a/src/components/NewExperiment/experimentFormData.js
+++ b/src/components/NewExperiment/experimentFormData.js
@@ -1,14 +1,6 @@
 export const paramsList = {
   "pod-scenarios": [
     {
-      key: "kubeconfigPath",
-      label: "KUBECONFIG PATH",
-      fieldId: "configPath-id",
-      ariaDescribedby: "kubeconfig-path",
-      helperText: "",
-      isRequired: false,
-    },
-    {
       key: "name",
       label: "Name",
       fieldId: "name-id",
@@ -76,14 +68,6 @@ export const paramsList = {
   ],
   "container-scenarios": [
     {
-      key: "kubeconfigPath",
-      label: "KUBECONFIG PATH",
-      fieldId: "configPath-id",
-      ariaDescribedby: "kubeconfig-path",
-      helperText: "",
-      isRequired: false,
-    },
-    {
       key: "name",
       label: "Name",
       fieldId: "name-id",
@@ -142,14 +126,6 @@ export const paramsList = {
     },
   ],
   "namespace-scenarios": [
-    {
-      key: "kubeconfigPath",
-      label: "KUBECONFIG PATH",
-      fieldId: "configPath-id",
-      ariaDescribedby: "kubeconfig-path",
-      helperText: "",
-      isRequired: false,
-    },
     {
       key: "name",
       label: "Name",
@@ -210,14 +186,6 @@ export const paramsList = {
   ],
   "node-scenarios": [
     {
-      key: "kubeconfigPath",
-      label: "KUBECONFIG PATH",
-      fieldId: "configPath-id",
-      ariaDescribedby: "kubeconfig-path",
-      helperText: "",
-      isRequired: false,
-    },
-    {
       key: "name",
       label: "Name",
       fieldId: "name-id",
@@ -244,14 +212,6 @@ export const paramsList = {
     },
   ],
   "pvc-scenarios": [
-    {
-      key: "kubeconfigPath",
-      label: "KUBECONFIG PATH",
-      fieldId: "configPath-id",
-      ariaDescribedby: "kubeconfig-path",
-      helperText: "",
-      isRequired: false,
-    },
     {
       key: "name",
       label: "Name",
@@ -302,14 +262,6 @@ export const paramsList = {
     },
   ],
   "time-scenarios": [
-    {
-      key: "kubeconfigPath",
-      label: "KUBECONFIG PATH",
-      fieldId: "configPath-id",
-      ariaDescribedby: "kubeconfig-path",
-      helperText: "",
-      isRequired: false,
-    },
     {
       key: "name",
       label: "Name",
@@ -369,14 +321,6 @@ export const paramsList = {
   ],
   "power-outages": [
     {
-      key: "kubeconfigPath",
-      label: "KUBECONFIG PATH",
-      fieldId: "configPath-id",
-      ariaDescribedby: "kubeconfig-path",
-      helperText: "",
-      isRequired: false,
-    },
-    {
       key: "name",
       label: "Name",
       fieldId: "name-id",
@@ -410,14 +354,6 @@ export const paramsList = {
     },
   ],
   "node-cpu-hog": [
-    {
-      key: "kubeconfigPath",
-      label: "KUBECONFIG PATH",
-      fieldId: "configPath-id",
-      ariaDescribedby: "kubeconfig-path",
-      helperText: "",
-      isRequired: false,
-    },
     {
       key: "name",
       label: "Name",
@@ -469,14 +405,6 @@ export const paramsList = {
     },
   ],
   "node-io-hog": [
-    {
-      key: "kubeconfigPath",
-      label: "KUBECONFIG PATH",
-      fieldId: "configPath-id",
-      ariaDescribedby: "kubeconfig-path",
-      helperText: "",
-      isRequired: false,
-    },
     {
       key: "name",
       label: "Name",
@@ -536,14 +464,6 @@ export const paramsList = {
     },
   ],
   "node-memory-hog": [
-    {
-      key: "kubeconfigPath",
-      label: "KUBECONFIG PATH",
-      fieldId: "configPath-id",
-      ariaDescribedby: "kubeconfig-path",
-      helperText: "",
-      isRequired: false,
-    },
     {
       key: "name",
       label: "Name",

--- a/src/components/NewExperiment/index.jsx
+++ b/src/components/NewExperiment/index.jsx
@@ -163,10 +163,14 @@ const NewExperiment = () => {
           </div>*/}
 
           <Grid hasGutter>
-            <GridItem span={6}>
-              <FormGroup isRequired={false} label={"KUBECONFIG FILE"}>
-                <KubeconfigFileUpload />
-              </FormGroup>
+            <GridItem span={12}>
+              <Grid hasGutter>
+                <GridItem span={6}>
+                  <FormGroup isRequired={false} label={"KUBECONFIG FILE"}>
+                    <KubeconfigFileUpload />
+                  </FormGroup>
+                </GridItem>
+              </Grid>
             </GridItem>
             {scenarioChecked &&
               paramsList[scenarioChecked].map((item) => {

--- a/src/components/Overview/index.less
+++ b/src/components/Overview/index.less
@@ -111,10 +111,8 @@
 }
 
 .file-path-container {
-  display: flex;
-  .or-clause {
-    margin: 5px;
-  }
+  display: block;
+  width: 100%;
   .pf-v5-c-file-upload {
     width: 100%;
   }

--- a/src/components/molecules/FileUpload/index.jsx
+++ b/src/components/molecules/FileUpload/index.jsx
@@ -30,7 +30,6 @@ const KubeconfigFileUpload = () => {
         onClearClick={handleClear}
         browseButtonText="Upload"
       />
-      <span className="or-clause">or</span>
     </div>
   );
 };

--- a/src/components/organisms/Header/index.jsx
+++ b/src/components/organisms/Header/index.jsx
@@ -35,7 +35,7 @@ const Header = () => {
       </MastheadToggle>
       <MastheadMain>
         <MastheadBrand href="/">
-          {import.meta.env.CONTAINER_BUILD ? (
+          {import.meta.env.EXTERNAL_CONTAINER_BUILD ? (
             <Brand
               src={`${import.meta.env.CHAOS_ASSETS}/logo/logo.png`}
               className="header-logo"


### PR DESCRIPTION
This change is a part of https://redhat.atlassian.net/browse/CHAOS-1386
Krknctl requires a direct path to the mounted directory (/usr/src/chaos-dashboard/src/assets) with the kubeconfig. Without it, podman cannot find the file and will not run the the container scenarios.

This variable is used on the krknctl side to successfully pull up a functional image of the dashboard.
**This change must be merged in before the PR in https://github.com/krkn-chaos/krknctl/pull/134**