### PR TITLE
replay feature CHAOS-1574

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -1,6 +1,7 @@
 import * as path from "path";
 import fs from "fs";
 
+import { extractReplayBaseStem, formatReplayTimestampSuffix } from "./pastRuns.js";
 import { fileURLToPath } from "url";
 import sqlite3 from "sqlite3";
 
@@ -64,6 +65,24 @@ db.exec(`CREATE TABLE IF NOT EXISTS details (
 db.run("ALTER TABLE details ADD COLUMN stored_at TEXT", (e) => {
   if (e && !/duplicate column name/i.test(String(e?.message || ""))) {
     console.warn("[db] ALTER TABLE details ADD COLUMN stored_at:", e?.message);
+  }
+});
+
+db.run("ALTER TABLE details ADD COLUMN scenario_params TEXT", (e) => {
+  if (e && !/duplicate column name/i.test(String(e?.message || ""))) {
+    console.warn("[db] ALTER TABLE details ADD COLUMN scenario_params:", e?.message);
+  }
+});
+
+db.run("ALTER TABLE details ADD COLUMN replay_of_container_id TEXT", (e) => {
+  if (e && !/duplicate column name/i.test(String(e?.message || ""))) {
+    console.warn("[db] ALTER TABLE details ADD COLUMN replay_of_container_id:", e?.message);
+  }
+});
+
+db.run("ALTER TABLE details ADD COLUMN run_kind TEXT DEFAULT 'original'", (e) => {
+  if (e && !/duplicate column name/i.test(String(e?.message || ""))) {
+    console.warn("[db] ALTER TABLE details ADD COLUMN run_kind:", e?.message);
   }
 });
 
@@ -176,14 +195,43 @@ export const deleteConfig = (id) => {
   });
 };
 
-export const savePodDetails = (containerId, image, mounts, state, status, name, content) => {
+/**
+ * @param {{ scenario_params?: string | null, replay_of_container_id?: string | null, run_kind?: string | null }} [meta]
+ */
+export const savePodDetails = (
+  containerId,
+  image,
+  mounts,
+  state,
+  status,
+  name,
+  content,
+  meta = {}
+) => {
+  const {
+    scenario_params = null,
+    replay_of_container_id = null,
+    run_kind = null,
+  } = meta;
   return new Promise((resolve, reject) => {
     const sql = `INSERT OR REPLACE INTO details(
-      container_id, image, mounts, state, status, name, content, stored_at
-    ) VALUES (?,?,?,?,?,?,?, datetime('now'))`;
+      container_id, image, mounts, state, status, name, content, stored_at,
+      scenario_params, replay_of_container_id, run_kind
+    ) VALUES (?,?,?,?,?,?,?, datetime('now'),?,?,?)`;
     db.run(
       sql,
-      [containerId, image, mounts, state, status, name, content],
+      [
+        containerId,
+        image,
+        mounts,
+        state,
+        status,
+        name,
+        content,
+        scenario_params,
+        replay_of_container_id,
+        run_kind,
+      ],
       function(err) {
         if (err) {
           console.log(err);
@@ -196,3 +244,60 @@ export const savePodDetails = (containerId, image, mounts, state, status, name, 
     );
   });
 };
+
+export const getDetailsByContainerId = (containerId) => {
+  return new Promise((resolve, reject) => {
+    const sql = `SELECT * FROM details WHERE container_id = ? LIMIT 1`;
+    db.get(sql, [containerId], (err, row) => {
+      if (err) {
+        reject({
+          status: 300,
+          message: "error getting details by container id",
+          error: err,
+        });
+      } else {
+        resolve(row || null);
+      }
+    });
+  });
+};
+
+/** Compare display names with optional leading slash from Podman */
+export const isStoredRunNameTaken = (bareName) => {
+  const normalized = String(bareName ?? "").trim().replace(/^\//, "");
+  return new Promise((resolve, reject) => {
+    const sql = `SELECT 1 AS ok FROM details WHERE TRIM(REPLACE(name, '/', '')) = ? LIMIT 1`;
+    db.get(sql, [normalized], (err, row) => {
+      if (err) reject(err);
+      else resolve(Boolean(row?.ok));
+    });
+  });
+};
+
+export async function allocateUniqueReplayDisplayName(rawStem) {
+  const stem = extractReplayBaseStem(rawStem);
+  const ts = formatReplayTimestampSuffix();
+  let candidate = `${stem}-replay-${ts}`;
+  if (!(await isStoredRunNameTaken(candidate))) return candidate;
+  let n = 2;
+  while (n < 100000) {
+    const c = `${stem}-replay-${ts}-${n}`;
+    if (!(await isStoredRunNameTaken(c))) return c;
+    n += 1;
+  }
+  throw new Error("Could not allocate unique replay name");
+}
+
+/** Walk replay chain to the root original run container id */
+export async function resolveReplayRootContainerId(containerId) {
+  let id = String(containerId ?? "").trim();
+  const seen = new Set();
+  for (let i = 0; i < 100; i++) {
+    if (!id || seen.has(id)) break;
+    seen.add(id);
+    const row = await getDetailsByContainerId(id);
+    if (!row?.replay_of_container_id) return id;
+    id = String(row.replay_of_container_id).trim();
+  }
+  return String(containerId ?? "").trim();
+}

--- a/server/index.js
+++ b/server/index.js
@@ -2,10 +2,13 @@
 import * as path from "path";
 
 import {
+  allocateUniqueReplayDisplayName,
   deleteConfig,
   getConfig,
+  getDetailsByContainerId,
   getDetailsForAnalytics,
   getResults,
+  resolveReplayRootContainerId,
   saveConfig,
   savePodDetails,
 } from "./db.js";
@@ -16,10 +19,15 @@ import {
   fetchSummaryFromOpenSearch,
 } from "./opensearch/index.js";
 import {
+  buildRunGroupsFromRows,
   computeStats,
+  enrichRunRow,
   filterByNameRegex,
   filterRowsByOutcome,
+  filterRowsByRunKind,
+  findGroupIndexForContainerId,
   rowOutcome,
+  sortRunGroups,
 } from "./pastRuns.js";
 
 import { fetchGrafanaDashboardList } from "./grafanaDashboardIndex.js";
@@ -72,8 +80,6 @@ function resolveKubeconfigPathForRequest(isFileUpload) {
   return getUploadKubeconfigPath();
 }
 
-let myInterval;
-
 chmodr(uploadFilePath, 0o777, (err) => {
   if (err) {
     console.log("Failed to execute chmod", err);
@@ -98,6 +104,62 @@ function getPodmanRunPlatformPrefix() {
   return "--platform linux/amd64 ";
 }
 const PODMAN_RUN_PLATFORM_PREFIX = getPodmanRunPlatformPrefix();
+
+/** Podman container name -> metadata persisted when the run completes */
+const pendingRunMetadata = new Map();
+
+/** normalized pod display name -> interval handle (each run polls independently) */
+const runPollIntervalsByPodName = new Map();
+/** normalized names we already persisted after exit (avoid duplicate INSERT OR REPLACE wiping meta) */
+const persistedExitByPodName = new Set();
+
+function normalizePodLookupKey(podName) {
+  return String(podName || "").trim().replace(/^\//, "");
+}
+
+/** Podman `run -d` prints full container id on stdout (first line). */
+function extractPodmanRunContainerId(stdout) {
+  const line = String(stdout || "")
+    .trim()
+    .split(/\r?\n/)
+    .find((l) => l.trim());
+  if (!line) return null;
+  const s = line.trim().replace(/^sha256:/i, "");
+  if (/^[a-f0-9]{64}$/i.test(s)) return s.toLowerCase();
+  if (/^[a-f0-9]{12,63}$/i.test(s)) return s.toLowerCase();
+  return null;
+}
+
+/**
+ * Try keys in order; remove every map entry pointing at the same meta object (name + container id aliases).
+ */
+function takePendingRunMetadata(...lookupKeys) {
+  let meta = null;
+  for (const raw of lookupKeys) {
+    if (raw == null || raw === undefined) continue;
+    const s = String(raw).trim();
+    if (!s) continue;
+    const variants = [
+      s,
+      s.replace(/^\//, ""),
+      s.length >= 12 ? s.slice(0, 12) : null,
+    ].filter(Boolean);
+    for (const k of variants) {
+      const m = pendingRunMetadata.get(k);
+      if (m) {
+        meta = m;
+        break;
+      }
+    }
+    if (meta) break;
+  }
+  if (meta) {
+    for (const [k, v] of [...pendingRunMetadata.entries()]) {
+      if (v === meta) pendingRunMetadata.delete(k);
+    }
+  }
+  return meta;
+}
 
 // Validates the podman socket before starting a container instance
 if (
@@ -128,9 +190,27 @@ if (
   }
 }
 
-app.post("/start-kraken/", (req, res) => {
+app.post("/start-kraken/", async (req, res) => {
   const scenario = req.body.params.scenarioChecked;
   const isFileUpload = Boolean(req.body.params?.isFileUpload);
+
+  let replayResolvedId = null;
+  const rawReplay = req.body.params?.replayOfContainerId;
+  if (rawReplay && String(rawReplay).trim()) {
+    try {
+      replayResolvedId = await resolveReplayRootContainerId(
+        String(rawReplay).trim()
+      );
+    } catch (e) {
+      console.warn("[start-kraken] resolveReplayRoot:", e?.message);
+      replayResolvedId = String(rawReplay).trim();
+    }
+  }
+
+  const paramsForMeta = {
+    ...req.body.params,
+    ...(replayResolvedId ? { replayOfContainerId: replayResolvedId } : {}),
+  };
 
   const kubeConfigFileLocation = resolveKubeconfigPathForRequest(isFileUpload);
   if (!fs.existsSync(kubeConfigFileLocation)) {
@@ -178,12 +258,47 @@ app.post("/start-kraken/", (req, res) => {
   // hit ERR_CHILD_PROCESS_STDIO_MAXBUFFER.
   child_process.exec(command, EXEC_LARGE_MAX_BUFFER, (err, stdout, stderr) => {
     if (!err) {
+      const params = paramsForMeta || {};
+      const replayOf = params.replayOfContainerId;
+      const runKind =
+        replayOf && String(replayOf).trim() ? "replay" : "original";
+      const nameKey = normalizePodLookupKey(params.name);
+      try {
+        const metaObj = {
+          scenario_params: JSON.stringify(params),
+          replay_of_container_id:
+            replayOf && String(replayOf).trim() ? String(replayOf).trim() : null,
+          run_kind: runKind,
+        };
+        pendingRunMetadata.set(nameKey, metaObj);
+        const runCid = extractPodmanRunContainerId(stdout);
+        if (runCid) {
+          pendingRunMetadata.set(runCid, metaObj);
+          if (runCid.length >= 12) {
+            pendingRunMetadata.set(runCid.slice(0, 12), metaObj);
+          }
+        }
+        persistedExitByPodName.delete(nameKey);
+      } catch (e) {
+        console.warn("[start-kraken] pendingRunMetadata:", e?.message);
+      }
       res.status(200).json({
         message: "Successfully created the container!",
         name: req.body.params.name,
         status: "200",
       });
-      myInterval = setInterval(() => myFunc(req.body.params.name), 1000 * 9);
+      {
+        const prevT = runPollIntervalsByPodName.get(nameKey);
+        if (prevT) {
+          clearInterval(prevT);
+          runPollIntervalsByPodName.delete(nameKey);
+        }
+        const pollT = setInterval(
+          () => myFunc(req.body.params.name),
+          1000 * 9
+        );
+        runPollIntervalsByPodName.set(nameKey, pollT);
+      }
       if (stderr) {
         console.log("[start-kraken] podman stderr (informational):", stripAnsi(stderr).slice(0, 2000));
       }
@@ -318,7 +433,42 @@ app.get("/getResults", async (req, res) => {
   }
 });
 
-/** Local DB past runs: filters (dates, image, name regex) + optional outcome table slice. */
+app.post("/past-runs/allocate-replay-name", async (req, res) => {
+  try {
+    const stem = req.body?.baseStem ?? req.body?.stem;
+    if (stem == null || String(stem).trim() === "") {
+      return res.status(400).json({ error: "baseStem is required" });
+    }
+    const name = await allocateUniqueReplayDisplayName(String(stem));
+    return res.json({ name });
+  } catch (err) {
+    console.error("allocate-replay-name:", err);
+    return res
+      .status(500)
+      .json({ error: err?.message || "Failed to allocate name" });
+  }
+});
+
+app.get("/past-runs/:containerId", async (req, res) => {
+  try {
+    const id = req.params.containerId;
+    if (!id || typeof id !== "string") {
+      return res.status(400).json({ error: "Invalid container id" });
+    }
+    const row = await getDetailsByContainerId(id);
+    if (!row) {
+      return res.status(404).json({ error: "Run not found" });
+    }
+    return res.json({ run: enrichRunRow(row) });
+  } catch (err) {
+    console.error("past-runs get:", err);
+    return res
+      .status(500)
+      .json({ error: err?.message || "Failed to load run" });
+  }
+});
+
+/** Local DB past runs: filters + grouped originals/replays + sort + pagination by group */
 app.post("/past-runs", async (req, res) => {
   try {
     const {
@@ -327,6 +477,10 @@ app.post("/past-runs", async (req, res) => {
       startDate = "",
       endDate = "",
       outcome = "all",
+      runKind = "all",
+      sortBy = "finishedAt",
+      sortDir = "desc",
+      focusContainerId = "",
       page = 1,
       perPage = 25,
     } = req.body || {};
@@ -342,25 +496,47 @@ app.post("/past-runs", async (req, res) => {
         .json({ error: `Invalid name regex: ${nameFilter.error}` });
     }
     rows = nameFilter.rows;
+    rows = filterRowsByRunKind(rows, runKind);
     const stats = computeStats(rows);
     const tableRows = filterRowsByOutcome(rows, outcome).map((r) => ({
-      ...r,
+      ...enrichRunRow(r),
       outcome: rowOutcome(r),
     }));
+    const safeSortBy =
+      sortBy === "name" || sortBy === "finishedAt" ? sortBy : "finishedAt";
+    const safeSortDir =
+      sortDir === "asc" || sortDir === "desc" ? sortDir : "desc";
+
+    let sortedGroups = sortRunGroups(
+      buildRunGroupsFromRows(tableRows, runKind),
+      safeSortBy,
+      safeSortDir
+    );
+
     const safePerPage = Math.min(
       25,
       Math.max(1, parseInt(String(perPage), 10) || 25)
     );
-    const safePage = Math.max(1, parseInt(String(page), 10) || 1);
-    const itemCount = tableRows.length;
+    let normalizedPage = Math.max(1, parseInt(String(page), 10) || 1);
+
+    const focusId =
+      typeof focusContainerId === "string" ? focusContainerId.trim() : "";
+    if (focusId) {
+      const fi = findGroupIndexForContainerId(sortedGroups, focusId);
+      if (fi >= 0) {
+        normalizedPage = Math.floor(fi / safePerPage) + 1;
+      }
+    }
+
+    const itemCount = sortedGroups.length;
     const totalPages = Math.max(1, Math.ceil(itemCount / safePerPage));
-    const normalizedPage = Math.min(safePage, totalPages);
+    normalizedPage = Math.min(normalizedPage, totalPages);
     const start = (normalizedPage - 1) * safePerPage;
-    const end = start + safePerPage;
-    const pagedRows = tableRows.slice(start, end);
+    const pagedGroups = sortedGroups.slice(start, start + safePerPage);
+
     return res.json({
       stats,
-      runs: pagedRows,
+      groups: pagedGroups,
       pagination: {
         page: normalizedPage,
         perPage: safePerPage,
@@ -373,6 +549,9 @@ app.post("/past-runs", async (req, res) => {
         startDate,
         endDate,
         outcome,
+        runKind,
+        sortBy: safeSortBy,
+        sortDir: safeSortDir,
       },
     });
   } catch (err) {
@@ -404,10 +583,16 @@ const persistCompletedRun = (podName) => {
 };
 
 const frame = async (status, podName) => {
-  if (status === "exited") {
-    clearInterval(myInterval);
-    persistCompletedRun(podName);
+  if (status !== "exited") return;
+  const pk = normalizePodLookupKey(podName);
+  const tid = runPollIntervalsByPodName.get(pk);
+  if (tid) {
+    clearInterval(tid);
+    runPollIntervalsByPodName.delete(pk);
   }
+  if (persistedExitByPodName.has(pk)) return;
+  persistedExitByPodName.add(pk);
+  persistCompletedRun(podName);
 };
 const myFunc = (podName) => {
   const command = `${PODMAN} inspect ${podName} --format "{{.State.Status}}"`;
@@ -443,6 +628,16 @@ const savePodDetailsToFile = async (podName, fileContent) => {
             : Array.isArray(row?.Names)
               ? row.Names[0]
               : podName;
+        const cidFromInspect = String(row.Id || "")
+          .replace(/^sha256:/i, "")
+          .trim()
+          .toLowerCase();
+        const meta = takePendingRunMetadata(
+          cidFromInspect,
+          cidFromInspect.length >= 12 ? cidFromInspect.slice(0, 12) : null,
+          podName,
+          displayName
+        );
         await savePodDetails(
           row.Id,
           row.ImageName || row.Image || "",
@@ -450,7 +645,8 @@ const savePodDetailsToFile = async (podName, fileContent) => {
           row.State?.Status ?? "",
           String(row.State?.ExitCode ?? ""),
           displayName,
-          fileContent
+          fileContent,
+          meta || {}
         );
       } catch (error) {
         console.log("Error saving pod details:", error);

--- a/server/pastRuns.js
+++ b/server/pastRuns.js
@@ -49,3 +49,153 @@ export function filterRowsByOutcome(rows, outcome) {
   }
   return rows;
 }
+
+/** @returns {"original" | "replay"} */
+export function normalizeRunKind(row) {
+  const k = String(row?.run_kind ?? "").trim().toLowerCase();
+  if (k === "replay") return "replay";
+  return "original";
+}
+
+export function filterRowsByRunKind(rows, runKind) {
+  if (runKind === "replay") {
+    return rows.filter((r) => normalizeRunKind(r) === "replay");
+  }
+  if (runKind === "original") {
+    return rows.filter((r) => normalizeRunKind(r) === "original");
+  }
+  return rows;
+}
+
+export function enrichRunRow(row) {
+  if (!row) return row;
+  let scenario_params = null;
+  const raw = row.scenario_params;
+  if (raw != null && String(raw).trim() !== "") {
+    try {
+      scenario_params = JSON.parse(String(raw));
+    } catch {
+      scenario_params = null;
+    }
+  }
+  return {
+    ...row,
+    scenario_params,
+    run_kind_normalized: normalizeRunKind(row),
+  };
+}
+
+/** Strip leading slash and prior `-replay-YYYYMMDD.HHMMSSLL(-N)?` suffix for stem extraction */
+export function extractReplayBaseStem(name) {
+  let s = String(name ?? "krkn-run").replace(/^\//, "");
+  s = s.replace(/-replay-\d{8}\.\d{8}(?:-\d+)?$/i, "");
+  return s.trim() || "krkn-run";
+}
+
+/** @returns {string} e.g. `20260510.14305247` — LL = two-digit millis fragment */
+export function formatReplayTimestampSuffix(d = new Date()) {
+  const p = (n, w = 2) => String(n).padStart(w, "0");
+  const ymd = `${d.getFullYear()}${p(d.getMonth() + 1)}${p(d.getDate())}`;
+  const hhmmssll = `${p(d.getHours())}${p(d.getMinutes())}${p(d.getSeconds())}${p(d.getMilliseconds() % 100)}`;
+  return `${ymd}.${hhmmssll}`;
+}
+
+export function displayNameFromRow(row) {
+  const n = row?.name || "";
+  return n.replace(/^\//, "") || row?.container_id?.slice(0, 12) || "—";
+}
+
+export function parseStoredAtMs(row) {
+  const s = row?.stored_at;
+  if (!s) return 0;
+  const t = Date.parse(String(s).replace(" ", "T"));
+  return Number.isNaN(t) ? 0 : t;
+}
+
+export function groupLatestFinishedMs(group) {
+  let m = parseStoredAtMs(group.root);
+  for (const r of group.replays) {
+    m = Math.max(m, parseStoredAtMs(r));
+  }
+  return m;
+}
+
+/**
+ * @param {object[]} rows enriched outcome-filtered rows
+ * @param {string} runKind filter from request
+ */
+export function buildRunGroupsFromRows(rows, runKind) {
+  if (runKind === "replay") {
+    return rows.map((r) => ({
+      root: r,
+      replays: [],
+      isFlatReplay: true,
+    }));
+  }
+
+  const enriched = rows;
+  const rootRows = enriched.filter((r) => !r.replay_of_container_id);
+  const byParent = new Map();
+  for (const r of enriched) {
+    const pid = r.replay_of_container_id;
+    if (!pid) continue;
+    const key = String(pid).trim();
+    if (!byParent.has(key)) byParent.set(key, []);
+    byParent.get(key).push(r);
+  }
+
+  const groups = [];
+  const coveredReplayIds = new Set();
+
+  for (const root of rootRows) {
+    const pid = root.container_id;
+    const replays = (byParent.get(pid) || []).slice();
+    replays.sort((a, b) => parseStoredAtMs(b) - parseStoredAtMs(a));
+    replays.forEach((r) => coveredReplayIds.add(r.container_id));
+    groups.push({ root, replays });
+  }
+
+  for (const r of enriched) {
+    if (!r.replay_of_container_id) continue;
+    if (coveredReplayIds.has(r.container_id)) continue;
+    groups.push({
+      root: r,
+      replays: [],
+      isOrphanReplay: true,
+    });
+  }
+
+  return groups;
+}
+
+export function sortRunGroups(groups, sortBy, sortDir) {
+  const dir = sortDir === "asc" ? 1 : -1;
+  const mut = [...groups];
+  if (sortBy === "name") {
+    mut.sort((a, b) => {
+      const cmp = displayNameFromRow(a.root).localeCompare(
+        displayNameFromRow(b.root),
+        undefined,
+        { sensitivity: "base" }
+      );
+      return dir * cmp;
+    });
+  } else {
+    mut.sort((a, b) => {
+      const ta = groupLatestFinishedMs(a);
+      const tb = groupLatestFinishedMs(b);
+      return dir * (ta - tb);
+    });
+  }
+  return mut;
+}
+
+export function findGroupIndexForContainerId(groups, containerId) {
+  if (!containerId) return -1;
+  const id = String(containerId).trim();
+  return groups.findIndex(
+    (g) =>
+      g.root.container_id === id ||
+      g.replays.some((r) => r.container_id === id)
+  );
+}

--- a/src/actions/newExperiment.js
+++ b/src/actions/newExperiment.js
@@ -33,6 +33,8 @@ export const startKraken = (data) => async (dispatch, getState) => {
       dispatch(getPodDetails());
       dispatch(saveConfig());
       dispatch(showToast("success", "Kraken started successfully!"));
+      dispatch({ type: TYPES.COMPLETED });
+      return true;
     } else {
       dispatch(showToast("danger", response.data.message));
     }
@@ -50,6 +52,7 @@ export const startKraken = (data) => async (dispatch, getState) => {
     }
   }
   dispatch({ type: TYPES.COMPLETED });
+  return false;
 };
 
 export const removePod = () => async (dispatch) => {

--- a/src/components/NewExperiment/index.jsx
+++ b/src/components/NewExperiment/index.jsx
@@ -2,6 +2,9 @@ import "./index.less";
 
 import {
   ActionGroup,
+  Alert,
+  AlertActionCloseButton,
+  Button,
   Card,
   CardBody,
   Form,
@@ -11,16 +14,42 @@ import {
   TextInput,
   Title,
 } from "@patternfly/react-core";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import KubeconfigFileUpload from "@/components/molecules/FileUpload";
 import { TextButton } from "@/components/atoms/Buttons/Buttons";
+import API from "@/utils/axiosInstance";
+import { extractReplayBaseStem } from "@/utils/replayNaming";
 import { paramsList } from "./experimentFormData";
-import { startKraken } from "@/actions/newExperiment";
+import { showToast } from "@/actions/toastActions";
+import { startKraken, updateScenarioChecked } from "@/actions/newExperiment";
+
+const mergeReplayScenarioFields = (stored, baseBlock) => {
+  const next = { ...baseBlock };
+  const skip = new Set(["replayOfContainerId", "isFileUpload", "name"]);
+  for (const [k, v] of Object.entries(stored)) {
+    if (skip.has(k)) continue;
+    if (
+      Object.prototype.hasOwnProperty.call(next, k) &&
+      v !== undefined &&
+      v !== null
+    ) {
+      next[k] = v;
+    }
+  }
+  next.scenarioChecked = stored.scenarioChecked;
+  return next;
+};
 
 const NewExperiment = () => {
   const dispatch = useDispatch();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const replayAppliedRef = useRef(false);
+  const [replaySourceRunId, setReplaySourceRunId] = useState(null);
+  const [replaySourceDisplayName, setReplaySourceDisplayName] = useState("");
   const [isBtnDisabled, setIsBtnDisabled] = useState(true);
   const scenarioChecked = useSelector(
     (state) => state.experiment.scenarioChecked
@@ -112,6 +141,59 @@ const NewExperiment = () => {
   });
 
   useEffect(() => {
+    if (replayAppliedRef.current) return;
+    const replay = location.state?.replay;
+    if (!replay?.params || !replay?.sourceContainerId) return;
+    const stored = replay.params;
+    const scenario = stored.scenarioChecked;
+    if (!scenario || !paramsList[scenario]) {
+      replayAppliedRef.current = true;
+      navigate(location.pathname, { replace: true, state: {} });
+      return;
+    }
+
+    replayAppliedRef.current = true;
+    const stem = extractReplayBaseStem(stored.name);
+    (async () => {
+      try {
+        const { data } = await API.post("/past-runs/allocate-replay-name", {
+          baseStem: stem,
+        });
+        const allocatedName = data?.name;
+        if (!allocatedName) throw new Error("No name returned");
+        setData((prev) => ({
+          ...prev,
+          [scenario]: {
+            ...mergeReplayScenarioFields(stored, prev[scenario]),
+            name: allocatedName,
+            scenarioChecked: scenario,
+          },
+        }));
+        dispatch(updateScenarioChecked(scenario));
+        setReplaySourceRunId(replay.sourceContainerId);
+        setReplaySourceDisplayName(
+          replay.sourceDisplayName != null && replay.sourceDisplayName !== ""
+            ? replay.sourceDisplayName
+            : stem
+        );
+      } catch (err) {
+        replayAppliedRef.current = false;
+        dispatch(
+          showToast(
+            "danger",
+            "Could not prepare replay",
+            err?.response?.data?.error ||
+              err?.message ||
+              "Unable to allocate a unique replay name."
+          )
+        );
+      } finally {
+        navigate(location.pathname, { replace: true, state: {} });
+      }
+    })();
+  }, [location.state, location.pathname, navigate, dispatch]);
+
+  useEffect(() => {
     const scenarioData = data[scenarioChecked];
     const scenarioParams = paramsList[scenarioChecked];
 
@@ -134,17 +216,25 @@ const NewExperiment = () => {
   }, [data, scenarioChecked]);
 
   const changeHandler = (_event, value, key) => {
-    setData((prevSatate) => ({
-      ...data,
+    setData((prevState) => ({
+      ...prevState,
       [scenarioChecked]: {
-        ...prevSatate[scenarioChecked],
+        ...prevState[scenarioChecked],
         [key]: value,
       },
     }));
   };
 
   const sendData = async () => {
-    await dispatch(startKraken(data[scenarioChecked]));
+    const base = { ...data[scenarioChecked] };
+    const payload = replaySourceRunId
+      ? { ...base, replayOfContainerId: replaySourceRunId }
+      : base;
+    const ok = await dispatch(startKraken(payload));
+    if (ok) {
+      setReplaySourceRunId(null);
+      setReplaySourceDisplayName("");
+    }
   };
 
   return (
@@ -163,6 +253,50 @@ const NewExperiment = () => {
           </div>*/}
 
           <Grid hasGutter>
+            {replaySourceRunId ? (
+              <GridItem span={12}>
+                <Alert
+                  isInline
+                  variant="info"
+                  title="Replayed from"
+                  actionClose={
+                    <AlertActionCloseButton
+                      onClose={() => {
+                        setReplaySourceRunId(null);
+                        setReplaySourceDisplayName("");
+                      }}
+                    />
+                  }
+                >
+                  <div className="new-experiment__replay-alert-desc">
+                    <div className="new-experiment__replay-alert-run-line">
+                      <Button
+                        variant="link"
+                        isInline
+                        className="new-experiment__replay-alert-run-link pf-v5-u-pl-0"
+                        component="a"
+                        href="/past-runs"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          navigate("/past-runs", {
+                            state: {
+                              focusContainerId: replaySourceRunId,
+                            },
+                          });
+                        }}
+                      >
+                        {replaySourceDisplayName || "Original"} —{" "}
+                        {replaySourceRunId}
+                      </Button>
+                    </div>
+                    <span className="new-experiment__replay-alert-hint">
+                      Adjust parameters below or upload another kubeconfig file to
+                      target a different cluster.
+                    </span>
+                  </div>
+                </Alert>
+              </GridItem>
+            ) : null}
             <GridItem span={12}>
               <Grid hasGutter>
                 <GridItem span={6}>

--- a/src/components/NewExperiment/index.less
+++ b/src/components/NewExperiment/index.less
@@ -11,3 +11,32 @@
   margin-left: auto;
   margin-right: auto;
 }
+
+/* Replay banner: run link on first line, hint flush underneath (no vertical gap) */
+.new-experiment__replay-alert-desc {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  align-items: flex-start;
+}
+
+.new-experiment__replay-alert-run-line {
+  margin: 0;
+  padding: 0;
+  line-height: 1.25;
+}
+
+.new-experiment__replay-alert-run-link.pf-v5-c-button.pf-m-link {
+  margin: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  line-height: inherit;
+}
+
+.new-experiment__replay-alert-hint {
+  display: block;
+  margin: 0;
+  padding: 0;
+  line-height: 1.25;
+  color: var(--pf-v5-global--Color--200);
+}

--- a/src/components/Overview/index.jsx
+++ b/src/components/Overview/index.jsx
@@ -65,7 +65,11 @@ const Overview = () => {
     <div className="overview-wrapper">
       <Card className="overview-card">
         <CardBody>
-          <Title headingLevel="h2" className="title-text pf-v5-u-mb-md">
+          <Title
+            headingLevel="h1"
+            size="3xl"
+            className="title-text overview__page-title pf-v5-u-mb-md"
+          >
             Run Kraken
           </Title>
           <div className="top-bar">

--- a/src/components/Overview/index.less
+++ b/src/components/Overview/index.less
@@ -1,3 +1,7 @@
+.overview__page-title {
+  line-height: 1.2;
+}
+
 .overview-wrapper {
   height: 100%;
   .overview-running-containers {

--- a/src/components/molecules/SideMenuOptions/index.jsx
+++ b/src/components/molecules/SideMenuOptions/index.jsx
@@ -43,11 +43,14 @@ const MenuOptions = () => {
   };
 
   useEffect(() => {
-    if (pathname !== "/") {
-      const currPath = pathname.replace(/^.*[/]([^/]+)[/]*$/, "$1");
-
-      dispatch(setActiveItem(currPath));
+    const normalized = (pathname || "/").replace(/\/+$/, "") || "/";
+    /* Index route is Run Kraken (Overview); pathname "/" must not leave sidebar on Past Runs */
+    if (normalized === "/" || normalized === "") {
+      dispatch(setActiveItem("overview"));
+      return;
     }
+    const currPath = pathname.replace(/^.*[/]([^/]+)[/]*$/, "$1");
+    dispatch(setActiveItem(currPath));
   }, [dispatch, pathname]);
   return (
     <>

--- a/src/components/template/Analysis/index.jsx
+++ b/src/components/template/Analysis/index.jsx
@@ -15,6 +15,7 @@ import {
   Text,
   TextContent,
   TextVariants,
+  Title,
 } from "@patternfly/react-core";
 import React, { useState } from "react";
 
@@ -51,8 +52,14 @@ const Analysis = () => {
   if (!connectionInfo.isConnected) {
     return (
       <Card>
-        <CardTitle>Connect to elastic search</CardTitle>
         <CardBody>
+          <Title
+            headingLevel="h1"
+            size="3xl"
+            className="analysis__page-title"
+          >
+            Connect to Elastic Search
+          </Title>
           <ESConnectForm />
         </CardBody>
       </Card>

--- a/src/components/template/Analysis/index.less
+++ b/src/components/template/Analysis/index.less
@@ -1,3 +1,11 @@
+.analysis__page-title {
+  line-height: 1.2;
+  /* Extra breathing room before the form (one line beyond default title spacing) */
+  margin-bottom: calc(
+    var(--pf-v5-global--spacer--md) + var(--pf-v5-global--spacer--lg)
+  );
+}
+
 .elastic-runs__runs-section {
   margin-top: 3rem;
 }

--- a/src/components/template/PastRuns/index.jsx
+++ b/src/components/template/PastRuns/index.jsx
@@ -20,18 +20,29 @@ import {
 } from "@patternfly/react-core";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import {
+  CaretDownIcon,
+  CaretRightIcon,
   CheckCircleIcon,
   DownloadIcon,
   ExclamationCircleIcon,
   TachometerAltIcon,
 } from "@patternfly/react-icons";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { downloadLogs } from "@/actions/newExperiment";
+import { showToast } from "@/actions/toastActions";
 import API from "@/utils/axiosInstance";
 import { useDispatch } from "react-redux";
+import { useLocation, useNavigate } from "react-router-dom";
 
-const formatStoredAt = (s) => {
+const formatFinishedAt = (s) => {
   if (s == null || s === "") return "—";
   return String(s).replace("T", " ").slice(0, 19);
 };
@@ -48,8 +59,23 @@ const emptyApplied = () => ({
   endDate: "",
 });
 
+const flattenGroupRows = (groups) => {
+  const out = [];
+  for (const g of groups || []) {
+    out.push(g.root);
+    for (const r of g.replays || []) {
+      out.push(r);
+    }
+  }
+  return out;
+};
+
 const PastRuns = () => {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const focusOnceRef = useRef(null);
+
   const [nameRegex, setNameRegex] = useState("");
   const [imageContains, setImageContains] = useState("");
   const [startDate, setStartDate] = useState("");
@@ -57,6 +83,10 @@ const PastRuns = () => {
   const [applied, setApplied] = useState(emptyApplied);
 
   const [outcome, setOutcome] = useState("all");
+  const [runKind, setRunKind] = useState("all");
+  const [sortBy, setSortBy] = useState("finishedAt");
+  const [sortDir, setSortDir] = useState("desc");
+
   const [selectedId, setSelectedId] = useState(null);
   const [page, setPage] = useState(1);
   const [pagination, setPagination] = useState({
@@ -72,63 +102,144 @@ const PastRuns = () => {
     fails: 0,
     passPercent: 0,
   });
-  const [runs, setRuns] = useState([]);
+  const [runGroups, setRunGroups] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+
+  const [expandedIds, setExpandedIds] = useState(() => new Set());
+  const [selectedFallback, setSelectedFallback] = useState(null);
+  const [parentRun, setParentRun] = useState(null);
+
+  useLayoutEffect(() => {
+    const id = location.state?.focusContainerId;
+    if (!id || typeof id !== "string") return;
+    const trimmed = id.trim();
+    focusOnceRef.current = trimmed;
+    navigate(location.pathname, { replace: true, state: {} });
+    setSelectedId(trimmed);
+  }, [location.state, location.pathname, navigate]);
 
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
+      const focusParam = focusOnceRef.current;
+      if (focusParam) {
+        focusOnceRef.current = null;
+      }
       const { data } = await API.post("/past-runs", {
         nameRegex: applied.nameRegex,
         imageContains: applied.imageContains,
         startDate: applied.startDate,
         endDate: applied.endDate,
         outcome,
+        runKind,
+        sortBy,
+        sortDir,
+        focusContainerId: focusParam || undefined,
         page,
         perPage: 25,
       });
-      const nextRuns = Array.isArray(data.runs) ? data.runs : [];
+      const nextGroups = Array.isArray(data.groups) ? data.groups : [];
       setStats(data.stats || { total: 0, passes: 0, fails: 0, passPercent: 0 });
-      setRuns(nextRuns);
+      setRunGroups(nextGroups);
       setPagination(
         data.pagination || { page: 1, perPage: 25, itemCount: 0, totalPages: 1 }
       );
       if (data?.pagination?.page && data.pagination.page !== page) {
         setPage(data.pagination.page);
       }
-      if (!nextRuns.some((row) => row.container_id === selectedId)) {
-        setSelectedId(nextRuns[0]?.container_id || null);
-      }
+
+      const flat = flattenGroupRows(nextGroups);
+      setSelectedId((prev) => {
+        if (flat.length === 0) return null;
+        if (focusParam && flat.some((row) => row.container_id === focusParam)) {
+          return focusParam;
+        }
+        if (prev && flat.some((row) => row.container_id === prev)) return prev;
+        return flat[0]?.container_id ?? null;
+      });
+
+      setExpandedIds(
+        new Set(
+          nextGroups
+            .filter((g) => g.replays?.length > 0 && !g.isFlatReplay)
+            .map((g) => g.root.container_id)
+        )
+      );
     } catch (e) {
       const msg =
         e?.response?.data?.error ||
         e?.message ||
         "Failed to load past runs";
       setError(msg);
-      setRuns([]);
+      setRunGroups([]);
       setPagination({ page: 1, perPage: 25, itemCount: 0, totalPages: 1 });
       setSelectedId(null);
     } finally {
       setLoading(false);
     }
-  }, [applied, outcome, page, selectedId]);
+  }, [applied, outcome, runKind, sortBy, sortDir, page]);
 
   useEffect(() => {
     load();
   }, [load]);
 
-  const selected = useMemo(
-    () => runs.find((row) => row.container_id === selectedId) || null,
-    [runs, selectedId]
-  );
+  const selectedFromTable = useMemo(() => {
+    for (const g of runGroups) {
+      if (g.root.container_id === selectedId) return g.root;
+      const hit = g.replays?.find((r) => r.container_id === selectedId);
+      if (hit) return hit;
+    }
+    return null;
+  }, [runGroups, selectedId]);
+
+  useEffect(() => {
+    if (!selectedId || selectedFromTable) {
+      setSelectedFallback(null);
+      return;
+    }
+    let cancelled = false;
+    API.get(`/past-runs/${encodeURIComponent(selectedId)}`)
+      .then(({ data }) => {
+        if (!cancelled && data?.run) {
+          setSelectedFallback(data.run);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setSelectedFallback(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId, selectedFromTable]);
+
+  const detailRow = selectedFromTable || selectedFallback;
+
+  useEffect(() => {
+    const pid = detailRow?.replay_of_container_id;
+    if (!pid) {
+      setParentRun(null);
+      return;
+    }
+    let cancelled = false;
+    API.get(`/past-runs/${encodeURIComponent(pid)}`)
+      .then(({ data }) => {
+        if (!cancelled && data?.run) setParentRun(data.run);
+      })
+      .catch(() => {
+        if (!cancelled) setParentRun(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [detailRow?.replay_of_container_id]);
 
   const logLines = useMemo(() => {
-    const raw = selected?.content;
+    const raw = detailRow?.content;
     if (raw == null || raw === "") return [];
     return String(raw).split(/\r?\n/);
-  }, [selected]);
+  }, [detailRow]);
 
   const applyFilters = (ev) => {
     ev.preventDefault();
@@ -141,10 +252,129 @@ const PastRuns = () => {
     setPage(1);
   };
 
+  const toggleExpand = (rootId, ev) => {
+    ev.stopPropagation();
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(rootId)) next.delete(rootId);
+      else next.add(rootId);
+      return next;
+    });
+  };
+
+  const toggleSort = (field) => {
+    if (sortBy === field) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortBy(field);
+      setSortDir(field === "name" ? "asc" : "desc");
+    }
+    setPage(1);
+  };
+
+  const goReplay = async () => {
+    const row = detailRow;
+    if (!row?.scenario_params?.scenarioChecked) {
+      dispatch(
+        showToast(
+          "warning",
+          "Replay unavailable",
+          "Scenario configuration was not stored for this run."
+        )
+      );
+      return;
+    }
+
+    let cfg = row.scenario_params;
+    let sourceId = row.container_id;
+    let sourceDisplayName = displayName(row);
+
+    if (row.run_kind_normalized === "replay") {
+      const parentId = row.replay_of_container_id;
+      if (!parentId) {
+        dispatch(
+          showToast(
+            "warning",
+            "Replay unavailable",
+            "Original run reference is missing."
+          )
+        );
+        return;
+      }
+      try {
+        const { data } = await API.get(
+          `/past-runs/${encodeURIComponent(parentId)}`
+        );
+        const orig = data?.run;
+        if (!orig?.scenario_params?.scenarioChecked) {
+          dispatch(
+            showToast(
+              "warning",
+              "Replay unavailable",
+              "Could not load the original run configuration."
+            )
+          );
+          return;
+        }
+        cfg = orig.scenario_params;
+        sourceId = orig.container_id;
+        sourceDisplayName = displayName(orig);
+      } catch {
+        dispatch(
+          showToast(
+            "danger",
+            "Replay failed",
+            "Could not load the original run."
+          )
+        );
+        return;
+      }
+    }
+
+    navigate("/", {
+      state: {
+        replay: {
+          sourceContainerId: sourceId,
+          sourceDisplayName,
+          params: cfg,
+        },
+      },
+    });
+  };
+
+  const SortArrow = ({ field }) => {
+    const active = sortBy === field;
+    return (
+      <span className="past-runs__sort-icons" aria-hidden>
+        <span
+          className={
+            active && sortDir === "asc"
+              ? "past-runs__sort-active"
+              : "past-runs__sort-idle"
+          }
+        >
+          ▲
+        </span>
+        <span
+          className={
+            active && sortDir === "desc"
+              ? "past-runs__sort-active"
+              : "past-runs__sort-idle"
+          }
+        >
+          ▼
+        </span>
+      </span>
+    );
+  };
+
   return (
-    <div className="past-runs">
+    <div className="overview-wrapper">
+      <Card className="overview-card">
+        <CardBody>
+          <div className="past-runs">
       <div className="past-runs__header">
-        <Title headingLevel="h1" size="2xl">
+        <Title headingLevel="h1" size="3xl" className="past-runs__page-title">
           Past runs
         </Title>
         <Button variant="secondary" onClick={load} isDisabled={loading}>
@@ -152,17 +382,38 @@ const PastRuns = () => {
         </Button>
       </div>
 
+      <div className="past-runs__body-rail">
       <Form className="past-runs__filters" onSubmit={applyFilters}>
         <div className="past-runs__filter-grid">
-          <FormGroup label="Name (regex)" fieldId="pr-name-regex">
+          <FormGroup label="Name" fieldId="pr-name-regex">
             <TextInput
               id="pr-name-regex"
               value={nameRegex}
               onChange={(_e, v) => setNameRegex(v)}
-              placeholder="e.g. ^test-|^prod-"
+              placeholder=""
             />
           </FormGroup>
-          <FormGroup label="Image contains" fieldId="pr-image">
+          <FormGroup label="Run type" fieldId="pr-run-kind">
+            <div className="pf-v5-c-form-control past-runs__run-type-wrap">
+              <select
+                id="pr-run-kind"
+                aria-label="Run type"
+                value={runKind}
+                onChange={(e) => {
+                  setRunKind(e.target.value);
+                  setPage(1);
+                }}
+              >
+                <option value="all">All runs</option>
+                <option value="original">Original only</option>
+                <option value="replay">Replay only</option>
+              </select>
+              <span className="past-runs__run-type-caret" aria-hidden="true">
+                <CaretDownIcon />
+              </span>
+            </div>
+          </FormGroup>
+          <FormGroup label="Image" fieldId="pr-image">
             <TextInput
               id="pr-image"
               value={imageContains}
@@ -186,7 +437,7 @@ const PastRuns = () => {
               onChange={(_e, v) => setEndDate(v)}
             />
           </FormGroup>
-          <FormGroup label=" " fieldId="pr-submit">
+          <FormGroup fieldId="pr-submit" className="past-runs__filter-submit">
             <Button variant="primary" type="submit" isDisabled={loading}>
               Apply filters
             </Button>
@@ -260,7 +511,7 @@ const PastRuns = () => {
         </Card>
       </div>
 
-      <Title headingLevel="h2" size="lg" className="past-runs__table-title">
+      <Title headingLevel="h2" size="xl" className="past-runs__table-title">
         {outcome === "all" && "Runs"}
         {outcome === "pass" && "Passed runs"}
         {outcome === "fail" && "Failed runs"}
@@ -271,44 +522,123 @@ const PastRuns = () => {
         <Table aria-label="Past runs table" variant="compact">
           <Thead>
             <Tr>
-              <Th>Name</Th>
-              <Th>Image</Th>
-              <Th>State</Th>
-              <Th>Exit code</Th>
-              <Th>Outcome</Th>
-              <Th>Stored at</Th>
+              <Th className="past-runs__th-name">
+                <Button
+                  type="button"
+                  variant="plain"
+                  className="past-runs__sort-heading"
+                  onClick={() => toggleSort("name")}
+                >
+                  Name <SortArrow field="name" />
+                </Button>
+              </Th>
+              <Th className="past-runs__th-plain">Type</Th>
+              <Th className="past-runs__th-plain">Image</Th>
+              <Th className="past-runs__th-plain">State</Th>
+              <Th className="past-runs__th-plain">Exit code</Th>
+              <Th className="past-runs__th-plain">Outcome</Th>
+              <Th className="past-runs__th-finished">
+                <Button
+                  type="button"
+                  variant="plain"
+                  className="past-runs__sort-heading"
+                  onClick={() => toggleSort("finishedAt")}
+                >
+                  Finished at <SortArrow field="finishedAt" />
+                </Button>
+              </Th>
             </Tr>
           </Thead>
           <Tbody>
             {!loading &&
-              runs.map((row) => (
-                <Tr
-                  key={row.container_id}
-                  className={
-                    selectedId === row.container_id
-                      ? "past-runs__row past-runs__row--selected"
-                      : "past-runs__row"
+              runGroups.flatMap((group) => {
+                const rootId = group.root.container_id;
+                const hasNested =
+                  group.replays?.length > 0 && !group.isFlatReplay;
+                const expanded = expandedIds.has(rootId);
+                const rowsOut = [];
+
+                const renderRow = (row, { nested }) => {
+                  const isSel = selectedId === row.container_id;
+                  return (
+                    <Tr
+                      key={row.container_id}
+                      className={
+                        isSel
+                          ? `past-runs__row past-runs__row--selected${nested ? " past-runs__row--replay" : ""}`
+                          : `past-runs__row${nested ? " past-runs__row--replay" : ""}`
+                      }
+                      onClick={() => setSelectedId(row.container_id)}
+                    >
+                      <Td className="past-runs__td-name">
+                        <div className="past-runs__name-cell">
+                          <span className="past-runs__tree-slot">
+                            {!nested && hasNested ? (
+                              <Button
+                                variant="plain"
+                                type="button"
+                                size="sm"
+                                className="past-runs__expand-btn"
+                                aria-expanded={expanded}
+                                onClick={(e) => toggleExpand(rootId, e)}
+                              >
+                                {expanded ? (
+                                  <CaretDownIcon />
+                                ) : (
+                                  <CaretRightIcon />
+                                )}
+                              </Button>
+                            ) : (
+                              <span className="past-runs__tree-slot-spacer" />
+                            )}
+                          </span>
+                          {nested ? (
+                            <span
+                              className="past-runs__replay-indent"
+                              aria-hidden
+                            />
+                          ) : null}
+                          <span className="past-runs__name-text">
+                            {displayName(row)}
+                          </span>
+                        </div>
+                      </Td>
+                      <Td>
+                        {row.run_kind_normalized === "replay" ? (
+                          <Label color="blue" isCompact>
+                            Replay
+                          </Label>
+                        ) : (
+                          <Label isCompact>Original</Label>
+                        )}
+                      </Td>
+                      <Td>{row.image || "—"}</Td>
+                      <Td>{row.state || "—"}</Td>
+                      <Td>{row.status ?? "—"}</Td>
+                      <Td>
+                        {row.outcome === "pass" ? (
+                          <Label color="green" isCompact>
+                            Pass
+                          </Label>
+                        ) : (
+                          <Label color="red" isCompact>
+                            Fail
+                          </Label>
+                        )}
+                      </Td>
+                      <Td>{formatFinishedAt(row.stored_at)}</Td>
+                    </Tr>
+                  );
+                };
+
+                rowsOut.push(renderRow(group.root, { nested: false }));
+                if (hasNested && expanded) {
+                  for (const r of group.replays) {
+                    rowsOut.push(renderRow(r, { nested: true }));
                   }
-                  onClick={() => setSelectedId(row.container_id)}
-                >
-                  <Td>{displayName(row)}</Td>
-                  <Td>{row.image || "—"}</Td>
-                  <Td>{row.state || "—"}</Td>
-                  <Td>{row.status ?? "—"}</Td>
-                  <Td>
-                    {row.outcome === "pass" ? (
-                      <Label color="green" isCompact>
-                        Pass
-                      </Label>
-                    ) : (
-                      <Label color="red" isCompact>
-                        Fail
-                      </Label>
-                    )}
-                  </Td>
-                  <Td>{formatStoredAt(row.stored_at)}</Td>
-                </Tr>
-              ))}
+                }
+                return rowsOut;
+              })}
           </Tbody>
         </Table>
       </div>
@@ -323,13 +653,14 @@ const PastRuns = () => {
         />
       </div>
 
-      {!loading && runs.length === 0 && (
+      {!loading && runGroups.length === 0 && (
         <p className="pf-v5-u-mt-md pf-v5-u-color-200">
           No runs match the current filters.
         </p>
       )}
+      </div>
 
-      {!selected ? (
+      {!detailRow ? (
         <Card className="past-runs__detail-card">
           <CardBody>
             <EmptyState>
@@ -344,58 +675,107 @@ const PastRuns = () => {
           <Card className="past-runs__detail-card">
             <CardTitle className="past-runs__detail-title">
               <span>Run details</span>
-              <Button
-                variant="link"
-                icon={<DownloadIcon />}
-                iconPosition="end"
-                onClick={() => dispatch(downloadLogs(displayName(selected)))}
-              >
-                Download live pod logs
-              </Button>
+              <span className="past-runs__detail-actions">
+                <Button
+                  variant="secondary"
+                  onClick={goReplay}
+                  isDisabled={
+                    loading || !detailRow?.scenario_params?.scenarioChecked
+                  }
+                >
+                  Replay
+                </Button>
+                <Button
+                  variant="link"
+                  icon={<DownloadIcon />}
+                  iconPosition="end"
+                  onClick={() =>
+                    dispatch(downloadLogs(displayName(detailRow)))
+                  }
+                >
+                  Download live pod logs
+                </Button>
+              </span>
             </CardTitle>
             <CardBody>
               <DescriptionList isCompact>
                 <DescriptionListGroup>
                   <DescriptionListTerm>Container</DescriptionListTerm>
                   <DescriptionListDescription>
-                    {displayName(selected)}
+                    {displayName(detailRow)}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
-                  <DescriptionListTerm>Container ID</DescriptionListTerm>
+                  <DescriptionListTerm>Run ID</DescriptionListTerm>
                   <DescriptionListDescription>
-                    {selected.container_id}
+                    {detailRow.container_id}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Run type</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {detailRow.run_kind_normalized === "replay"
+                      ? "Replay"
+                      : "Original"}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                {detailRow.replay_of_container_id ? (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Replayed from</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {parentRun ? (
+                        <Button
+                          variant="link"
+                          isInline
+                          className="pf-v5-u-pl-0"
+                          component="a"
+                          href="/past-runs"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            navigate("/past-runs", {
+                              state: {
+                                focusContainerId: parentRun.container_id,
+                              },
+                            });
+                          }}
+                        >
+                          {displayName(parentRun)} — {parentRun.container_id}
+                        </Button>
+                      ) : (
+                        detailRow.replay_of_container_id
+                      )}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                ) : null}
                 <DescriptionListGroup>
                   <DescriptionListTerm>Image</DescriptionListTerm>
                   <DescriptionListDescription>
-                    {selected.image}
+                    {detailRow.image}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
                   <DescriptionListTerm>Mount</DescriptionListTerm>
                   <DescriptionListDescription>
-                    {selected.mounts || "—"}
+                    {detailRow.mounts || "—"}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
                   <DescriptionListTerm>State</DescriptionListTerm>
                   <DescriptionListDescription>
-                    {selected.state}
+                    {detailRow.state}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
                   <DescriptionListTerm>Exit code</DescriptionListTerm>
                   <DescriptionListDescription>
-                    {selected.status}
+                    {detailRow.status}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
-                {selected.stored_at ? (
+                {detailRow.stored_at ? (
                   <DescriptionListGroup>
-                    <DescriptionListTerm>Stored at</DescriptionListTerm>
+                    <DescriptionListTerm>Finished at</DescriptionListTerm>
                     <DescriptionListDescription>
-                      {selected.stored_at}
+                      {detailRow.stored_at}
                     </DescriptionListDescription>
                   </DescriptionListGroup>
                 ) : null}
@@ -408,7 +788,7 @@ const PastRuns = () => {
               <div className="past-runs__logs" tabIndex={0}>
                 {logLines.map((line, index) => (
                   <div
-                    key={`${selected.container_id}-${index}`}
+                    key={`${detailRow.container_id}-${index}`}
                     className="past-runs__log-line"
                   >
                     {line}
@@ -419,6 +799,9 @@ const PastRuns = () => {
           </Card>
         </>
       )}
+          </div>
+        </CardBody>
+      </Card>
     </div>
   );
 };

--- a/src/components/template/PastRuns/index.less
+++ b/src/components/template/PastRuns/index.less
@@ -1,7 +1,8 @@
+@import "../../Overview/index.less";
+
+/* Page body sits inside PF Card (same shell as Run Kraken / Elastic runs) */
 .past-runs {
-  padding: 1rem 1.5rem 2rem;
-  max-width: 1400px;
-  margin: 0 auto;
+  width: 100%;
 
   &__header {
     display: flex;
@@ -9,21 +10,41 @@
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
-    margin-bottom: 1.5rem;
+    margin-bottom: 1rem;
+  }
+
+  /* Same idea as Overview `.top-bar`: grey band for filters + table under the title */
+  &__body-rail {
+    background: #f5f5f5;
+    margin-left: -1.5rem;
+    margin-right: -1.5rem;
+    margin-bottom: 1rem;
+    padding: var(--pf-v5-global--spacer--md) 1.5rem var(--pf-v5-global--spacer--lg);
   }
 
   &__filters {
-    background: var(--pf-v5-c-card--BackgroundColor, #f5f5f5);
+    background: var(--pf-v5-global--BackgroundColor--100, #fff);
     padding: 1rem 1.25rem;
     border-radius: 4px;
     margin-bottom: 1.5rem;
+    border: 1px solid var(--pf-v5-global--BorderColor--100, #d2d2d2);
   }
 
   &__filter-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
     gap: 1rem 1.25rem;
-    align-items: end;
+
+    /* Same row as inputs; share horizontal space until wrap */
+    > .pf-v5-c-form__group:not(.past-runs__filter-submit) {
+      flex: 1 1 11rem;
+      min-width: min(100%, 11rem);
+    }
+
+    .past-runs__filter-submit {
+      flex: 0 0 auto;
+    }
   }
 
   &__metrics {
@@ -71,8 +92,13 @@
     margin-top: 0.25rem;
   }
 
+  &__page-title {
+    line-height: 1.2;
+  }
+
   &__table-title {
     margin-bottom: 0.75rem;
+    line-height: 1.3;
   }
 
   &__pagination {
@@ -84,6 +110,10 @@
 
   &__row {
     cursor: pointer;
+
+    & > .pf-v5-c-table__td {
+      vertical-align: middle;
+    }
   }
 
   &__row--selected {
@@ -101,6 +131,150 @@
     justify-content: space-between;
     gap: 1rem;
     flex-wrap: wrap;
+  }
+
+  &__detail-actions {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  /* PF sets thead cell font-size + padding via `.pf-v5-c-table tr > *` + vars — beat it with thead/th chain + logical padding */
+  .pf-v5-c-table.pf-m-compact thead.pf-v5-c-table__thead tr.pf-v5-c-table__tr > th.past-runs__th-name {
+    vertical-align: bottom;
+    font-size: var(--pf-v5-global--FontSize--md);
+    font-weight: 600;
+    padding-inline-start: 2.5rem;
+    padding-left: 2.5rem;
+  }
+
+  .pf-v5-c-table.pf-m-compact thead.pf-v5-c-table__thead tr.pf-v5-c-table__tr > th.past-runs__th-plain,
+  .pf-v5-c-table.pf-m-compact thead.pf-v5-c-table__thead tr.pf-v5-c-table__tr > th.past-runs__th-finished {
+    vertical-align: bottom;
+    font-size: var(--pf-v5-global--FontSize--md);
+    font-weight: 600;
+  }
+
+  /** Decorative caret; native select cannot use PF toggle slot without overlapping text */
+  &__run-type-wrap > select {
+    --pf-v5-c-form-control--PaddingRight: calc(
+      var(--pf-v5-global--spacer--lg) + var(--pf-v5-global--spacer--md)
+    );
+  }
+
+  &__run-type-caret {
+    position: absolute;
+    right: var(--pf-v5-global--spacer--sm);
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+    display: flex;
+    align-items: center;
+    color: var(--pf-v5-global--icon--Color--light);
+    font-size: var(--pf-v5-global--FontSize--sm);
+    line-height: 1;
+  }
+
+  &__sort-heading.pf-v5-c-button.pf-m-plain {
+    padding-left: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    font-size: inherit;
+    font-weight: inherit;
+    color: inherit;
+    line-height: inherit;
+  }
+
+  .pf-v5-c-table.pf-m-compact tbody.pf-v5-c-table__tbody tr.pf-v5-c-table__tr > td.past-runs__td-name {
+    vertical-align: middle;
+    padding-inline-start: 2.5rem;
+    padding-left: 2.5rem;
+  }
+
+  &__name-cell {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0;
+    min-width: 0;
+  }
+
+  &__tree-slot {
+    flex: 0 0 2rem;
+    width: 2rem;
+    height: 1.25rem;
+    min-height: 1.25rem;
+    max-height: 1.25rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-start;
+    overflow: hidden;
+  }
+
+  &__tree-slot-spacer {
+    display: block;
+    width: 100%;
+    height: 1.25rem;
+    min-height: 1.25rem;
+    flex-shrink: 0;
+  }
+
+  &__replay-indent {
+    flex: 0 0 1.25rem;
+    width: 1.25rem;
+  }
+
+  &__name-text {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__sort-icons {
+    display: inline-flex;
+    flex-direction: column;
+    margin-left: 0.25rem;
+    font-size: 0.55rem;
+    line-height: 0.85;
+    vertical-align: middle;
+  }
+
+  &__sort-active {
+    color: var(--pf-v5-global--palette--black-900, #151515);
+    font-weight: 700;
+  }
+
+  &__sort-idle {
+    color: var(--pf-v5-global--palette--black-400, #b8bbbe);
+    font-weight: 400;
+  }
+
+  &__expand-btn.pf-v5-c-button {
+    --pf-v5-c-button--MinWidth: 1.25rem;
+    padding: 0 !important;
+    min-width: 1.25rem !important;
+    width: 1.25rem !important;
+    height: 1.25rem !important;
+    min-height: 1.25rem !important;
+    max-height: 1.25rem !important;
+    margin: 0 !important;
+    line-height: 1 !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+
+    svg {
+      width: 0.875rem;
+      height: 0.875rem;
+    }
+  }
+
+  &__row--replay:not(.past-runs__row--selected) td {
+    background-color: var(--pf-v5-global--palette--black-100, #f5f5f5);
+  }
+
+  &__row--selected.past-runs__row--replay td {
+    background-color: var(--pf-v5-global--palette--blue-50);
   }
 
   &__logs-card {

--- a/src/utils/replayNaming.js
+++ b/src/utils/replayNaming.js
@@ -1,0 +1,6 @@
+/** Match server `extractReplayBaseStem` for kube/Podman display names */
+export function extractReplayBaseStem(name) {
+  let s = String(name ?? "krkn-run").replace(/^\//, "");
+  s = s.replace(/-replay-\d{8}\.\d{8}(?:-\d+)?$/i, "");
+  return s.trim() || "krkn-run";
+}


### PR DESCRIPTION
Implements https://redhat.atlassian.net/browse/CHAOS-1574

Past Runs (Replay)
* Open Past Runs, select a run, then use Replay to run that scenario again.
* You are sent to Run Kraken with the scenario fields already filled in. Change anything you need before starting.
* To cancel the replay context, close the blue “Replayed from” banner (X) at the top of Supported Parameters.
* Replays of replays are not created as nested replays: if you replay a replay, the flow is rerouted to the original run’s configuration.

Past Runs (Table and filters)
* Original runs and their replays appear in the table; originals with replays can be expanded (dropdown/tree) to show child replay rows.
* Use the run type filter to show all runs, originals only, or replays only.
* In run details, a replay shows a link back to the original run it was replayed from.
* Replay names follow: [original_name]-replay-[datetime].

Added sorting by experiment name and date in Past Runs table