### PR TITLE
fixed the hardcoded pod disruption in elastic-runs

### DIFF
--- a/server/opensearch/runsList.js
+++ b/server/opensearch/runsList.js
@@ -35,11 +35,6 @@ export class ElasticRunListService {
             },
           },
         },
-        {
-          match: {
-            "scenarios.scenario_type": "pod_disruption_scenarios",
-          },
-        },
       ];
 
       if (appliedFilters && Object.keys(appliedFilters).length > 0) {


### PR DESCRIPTION
### Changes
The Elastic runs query in server/opensearch/runsList.js had a hardcoded filter clause forcing scenarios.scenario_type to equal pod_disruption_scenarios. Since that clause sat inside the query's bool.filter (which ANDs every condition), it silently restricted all results to pod-disruption runs no matter what date range or filters the user selected. I removed that one clause, so the query now filters only on the time range plus the user's chosen filters, returning every scenario type in the window. The rest of the code already handled mixed scenario types safely, so nothing else needed to change.

Fixes #62