### PR TITLE
feat: add support for Krkn-Hub top-level global scenario configuration variables

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -323,7 +323,7 @@ app.post("/start-kraken/", async (req, res) => {
   let command = "";
   switch (scenario) {
     case "pod-scenarios":
-      command = `${PODMAN} run ${PODMAN_RUN_PLATFORM_PREFIX} --env NAMESPACE=${req.body.params.namespace} --env NAME_PATTERN=${req.body.params.name_pattern} --env POD_LABEL=${req.body.params.pod_label} --env DISRUPTION_COUNT=${req.body.params.disruption_count}  --env KILL_TIMEOUT=${req.body.params.kill_timeout} --env WAIT_DURATION=${req.body.params.wait_timeout} --env EXPECTED_POD_COUNT=${req.body.params.expected_pod_count} --name=${req.body.params.name} --net=host -v ${kubeConfigPath}:/home/krkn/.kube/config:z -d quay.io/krkn-chaos/krkn-hub:pod-scenarios`;
+      command = `${PODMAN} run ${PODMAN_RUN_PLATFORM_PREFIX} --env NAMESPACE=${req.body.params.namespace} --env NAME_PATTERN=${req.body.params.name_pattern} --env POD_LABEL=${req.body.params.pod_label} --env DISRUPTION_COUNT=${req.body.params.disruption_count}  --env KILL_TIMEOUT=${req.body.params.kill_timeout} --env EXPECTED_POD_COUNT=${req.body.params.expected_pod_count} --name=${req.body.params.name} --net=host -v ${kubeConfigPath}:/home/krkn/.kube/config:z -d quay.io/krkn-chaos/krkn-hub:pod-scenarios`;
       break;
     case "container-scenarios":
       command = `${PODMAN} run ${PODMAN_RUN_PLATFORM_PREFIX} --env NAMESPACE=${req.body.params.namespace} --env LABEL_SELECTOR=${req.body.params.label_selector} --env DISRUPTION_COUNT=${req.body.params.disruption_count} --env CONTAINER_NAME=${req.body.params.container_name} --env ACTION=${req.body.params.action} --env EXPECTED_RECOVERY_TIME=${req.body.params.expected_recovery_time} --name=${req.body.params.name} --net=host  -v ${kubeConfigPath}:/home/krkn/.kube/config:z -d quay.io/krkn-chaos/krkn-hub:container-scenarios`;

--- a/server/index.js
+++ b/server/index.js
@@ -272,6 +272,18 @@ app.post("/check-cluster-runs", async (req, res) => {
 app.post("/start-kraken/", async (req, res) => {
   const scenario = req.body.params.scenarioChecked;
 
+  const globalParams = req.body.params?.globalParams;
+  const customEnv = { ...process.env };
+  let globalEnvFlags = "";
+  if (globalParams && typeof globalParams === "object") {
+    for (const [key, value] of Object.entries(globalParams)) {
+      if (value !== undefined && value !== null && value.toString().trim() !== "") {
+        customEnv[key] = String(value);
+        globalEnvFlags += ` --env ${key}`;
+      }
+    }
+  }
+
   let runCtx;
   try {
     runCtx = await resolveRunContext(
@@ -340,11 +352,15 @@ app.post("/start-kraken/", async (req, res) => {
     default:
       command = `echo 'No scenario selected'`;
   }
+  if (globalEnvFlags && command.startsWith(`${PODMAN} run`)) {
+    command = command.replace(`${PODMAN} run`, `${PODMAN} run${globalEnvFlags}`);
+  }
   console.log(command);
   // Podman prints pull/progress to stderr; a non-empty stderr is normal. Only treat
   // non-zero exit (err) as failure. Use a large buffer so first-time image pulls don't
   // hit ERR_CHILD_PROCESS_STDIO_MAXBUFFER.
-  child_process.exec(command, EXEC_LARGE_MAX_BUFFER, (err, stdout, stderr) => {
+  const execOptions = { ...EXEC_LARGE_MAX_BUFFER, env: customEnv };
+  child_process.exec(command, execOptions, (err, stdout, stderr) => {
     if (!err) {
       const params = paramsForMeta || {};
       const replayOf = params.replayOfContainerId;

--- a/src/components/NewExperiment/experimentFormData.js
+++ b/src/components/NewExperiment/experimentFormData.js
@@ -612,3 +612,74 @@ export const paramsList = {
     },
   ],
 };
+
+export const globalParamsData = [
+  {
+    category: "Kraken & Cerberus & Health Checks",
+    fields: [
+      { key: "PUBLISH_KRAKEN_STATUS", label: "Publish Kraken Status", helperText: "Publish kraken status to the signal address", defaultValue: "True" },
+      { key: "SIGNAL_ADDRESS", label: "Signal Address", helperText: "Address to publish kraken status to", defaultValue: "0.0.0.0" },
+      { key: "PORT", label: "Port", helperText: "Port to publish kraken status to", defaultValue: "8081" },
+      { key: "SIGNAL_STATE", label: "Signal State", helperText: "Waits for the RUN signal when set to PAUSE before running the scenarios", defaultValue: "RUN" },
+      { key: "CERBERUS_ENABLED", label: "Cerberus Enabled", helperText: "Set this to true if cerberus is running and monitoring the cluster", defaultValue: "False" },
+      { key: "CERBERUS_URL", label: "Cerberus URL", helperText: "URL to poll for the go/no-go signal", defaultValue: "http://0.0.0.0:8080" },
+      { key: "HEALTH_CHECK_URL", label: "Health Check URL", helperText: "URL to continually check and detect downtimes", defaultValue: "" },
+      { key: "HEALTH_CHECK_INTERVAL", label: "Health Check Interval", helperText: "Interval in seconds at which to run health checks", defaultValue: "2" },
+      { key: "HEALTH_CHECK_BEARER_TOKEN", label: "Health Check Bearer Token", helperText: "Bearer token used for authenticating into health check URL", defaultValue: "" },
+      { key: "HEALTH_CHECK_AUTH", label: "Health Check Auth", helperText: "Tuple of (username, password) used for authenticating into health check URL", defaultValue: "" },
+      { key: "HEALTH_CHECK_EXIT_ON_FAILURE", label: "Health Check Exit On Failure", helperText: "If True, exits when health check fails for application", defaultValue: "" },
+      { key: "HEALTH_CHECK_VERIFY", label: "Health Check Verify", helperText: "Health check URL SSL validation", defaultValue: "False" }
+    ]
+  },
+  {
+    category: "Performance & Metrics & Resiliency & Elastic",
+    fields: [
+      { key: "DEPLOY_DASHBOARDS", label: "Deploy Dashboards", helperText: "Deploys mutable grafana loaded with dashboards visualizing performance metrics", defaultValue: "False" },
+      { key: "CAPTURE_METRICS", label: "Capture Metrics", helperText: "Captures metrics as specified in the profile from in-cluster prometheus", defaultValue: "False" },
+      { key: "ENABLE_ALERTS", label: "Enable Alerts", helperText: "Evaluates expressions from in-cluster prometheus and exits 0 or 1", defaultValue: "False" },
+      { key: "ALERTS_PATH", label: "Alerts Path", helperText: "Path to the alerts file to use when ENABLE_ALERTS is set", defaultValue: "config/alerts" },
+      { key: "CHECK_CRITICAL_ALERTS", label: "Check Critical Alerts", helperText: "When enabled will check prometheus for critical alerts firing post chaos", defaultValue: "False" },
+      { key: "RESILIENCY_RUN_MODE", label: "Resiliency Run Mode", helperText: "Resiliency scoring mode: standalone, detailed, or disabled", defaultValue: "standalone" },
+      { key: "RESILIENCY_FILE", label: "Resiliency File", helperText: "Path to a YAML file containing SLO definitions", defaultValue: "config/alerts.yaml" },
+      { key: "ELASTIC_SERVER", label: "Elastic Server", helperText: "URL of the Elasticsearch instance to store telemetry data", defaultValue: "" },
+      { key: "ELASTIC_INDEX", label: "Elastic Index", helperText: "Elasticsearch index pattern to post results to", defaultValue: "" }
+    ]
+  },
+  {
+    category: "Tunings & Virt Checks",
+    fields: [
+      { key: "WAIT_DURATION", label: "Wait Duration", helperText: "Duration in seconds to wait between each chaos scenario", defaultValue: "60" },
+      { key: "ITERATIONS", label: "Iterations", helperText: "Number of times to execute the scenarios", defaultValue: "1" },
+      { key: "DAEMON_MODE", label: "Daemon Mode", helperText: "Iterations are set to infinity which means that the kraken will cause chaos forever", defaultValue: "False" },
+      { key: "KUBE_VIRT_CHECK_INTERVAL", label: "Kube Virt Check Interval", helperText: "Interval in seconds at which to test kubevirt connections", defaultValue: "2" },
+      { key: "KUBE_VIRT_NAMESPACE", label: "Kube Virt Namespace", helperText: "Namespace to find VMIs in and watch", defaultValue: "" },
+      { key: "KUBE_VIRT_NAME", label: "Kube Virt Name", helperText: "Regex style name to match VMIs to watch", defaultValue: "" },
+      { key: "KUBE_VIRT_FAILURES", label: "Kube Virt Failures", helperText: "If True, will only report when ssh connections fail to VMI", defaultValue: "" },
+      { key: "KUBE_VIRT_DISCONNECTED", label: "Kube Virt Disconnected", helperText: "Use disconnected check by passing cluster API", defaultValue: "False" },
+      { key: "KUBE_VIRT_NODE_NAME", label: "Kube Virt Node Name", helperText: "If set, will filter VMs to only track ones running on the specified node", defaultValue: "" },
+      { key: "KUBE_VIRT_EXIT_ON_FAIL", label: "Kube Virt Exit On Fail", helperText: "Fails run if VMs still have false status at end of run", defaultValue: "" },
+      { key: "KUBE_VIRT_SSH_NODE", label: "Kube Virt SSH Node", helperText: "If set, will be a backup way to SSH to a node", defaultValue: "" }
+    ]
+  },
+  {
+    category: "Telemetry",
+    fields: [
+      { key: "TELEMETRY_ENABLED", label: "Telemetry Enabled", helperText: "Enable/disables the telemetry collection feature", defaultValue: "False" },
+      { key: "TELEMETRY_API_URL", label: "Telemetry API URL", helperText: "Telemetry service endpoint", defaultValue: "https://ulnmf9xv7j.execute-api.us-west-2.amazonaws.com/production" },
+      { key: "TELEMETRY_USERNAME", label: "Telemetry Username", helperText: "Telemetry service username", defaultValue: "redhat-chaos" },
+      { key: "TELEMETRY_PASSWORD", label: "Telemetry Password", helperText: "Telemetry service password", defaultValue: "" },
+      { key: "TELEMETRY_PROMETHEUS_BACKUP", label: "Telemetry Prometheus Backup", helperText: "Enables/disables prometheus data collection", defaultValue: "True" },
+      { key: "TELEMTRY_FULL_PROMETHEUS_BACKUP", label: "Telemetry Full Prometheus Backup", helperText: "If set to False only the /prometheus/wal folder will be downloaded", defaultValue: "False" },
+      { key: "TELEMETRY_BACKUP_THREADS", label: "Telemetry Backup Threads", helperText: "Number of telemetry download/upload threads", defaultValue: "5" },
+      { key: "TELEMETRY_ARCHIVE_PATH", label: "Telemetry Archive Path", helperText: "Local path where the archive files will be temporarily stored", defaultValue: "/tmp" },
+      { key: "TELEMETRY_MAX_RETRIES", label: "Telemetry Max Retries", helperText: "Maximum number of upload retries (if 0 will retry forever)", defaultValue: "0" },
+      { key: "TELEMETRY_RUN_TAG", label: "Telemetry Run Tag", helperText: "If set, this will be appended to the run folder in the S3 bucket", defaultValue: "chaos" },
+      { key: "TELEMETRY_GROUP", label: "Telemetry Group", helperText: "If set will archive the telemetry in the S3 bucket on a folder named after the value", defaultValue: "default" },
+      { key: "TELEMETRY_ARCHIVE_SIZE", label: "Telemetry Archive Size", helperText: "The size of the prometheus data archive in KB", defaultValue: "1000" },
+      { key: "TELEMETRY_LOGS_BACKUP", label: "Telemetry Logs Backup", helperText: "Logs backup to S3", defaultValue: "False" },
+      { key: "TELEMETRY_FILTER_PATTER", label: "Telemetry Filter Pattern", helperText: "Filter logs based on certain timestamp patterns", defaultValue: "" },
+      { key: "TELEMETRY_CLI_PATH", label: "Telemetry CLI Path", helperText: "OC CLI path, if not specified will be searched in $PATH", defaultValue: "" }
+    ]
+  }
+];
+

--- a/src/components/NewExperiment/experimentFormData.js
+++ b/src/components/NewExperiment/experimentFormData.js
@@ -50,14 +50,6 @@ export const paramsList = {
       isRequired: false,
     },
     {
-      key: "wait_timeout",
-      label: "Wait Timeout",
-      fieldId: "wait_timeout-id",
-      ariaDescribedby: "wait timeout",
-      helperText: "",
-      isRequired: false,
-    },
-    {
       key: "expected_pod_count",
       label: "Expected POD count",
       fieldId: "expected_pod_count-id",
@@ -635,14 +627,26 @@ export const globalParamsData = [
     category: "Performance & Metrics & Resiliency & Elastic",
     fields: [
       { key: "DEPLOY_DASHBOARDS", label: "Deploy Dashboards", helperText: "Deploys mutable grafana loaded with dashboards visualizing performance metrics", defaultValue: "False" },
+      { key: "PROMETHEUS_URI", label: "Prometheus URI", helperText: "URI to Prometheus instance; auto-detected on OpenShift, required for Kubernetes", defaultValue: "" },
+      { key: "PROMETHEUS_TOKEN", label: "Prometheus Token", helperText: "Bearer token for Prometheus authentication; auto-detected on OpenShift, required for Kubernetes", defaultValue: "" },
+      { key: "UUID", label: "UUID", helperText: "UUID for the run; auto generated if not set", defaultValue: "" },
       { key: "CAPTURE_METRICS", label: "Capture Metrics", helperText: "Captures metrics as specified in the profile from in-cluster prometheus", defaultValue: "False" },
+      { key: "METRICS_PATH", label: "Metrics Path", helperText: "Path to the metrics profile to use when CAPTURE_METRICS is set", defaultValue: "config/metrics-aggregated.yaml" },
       { key: "ENABLE_ALERTS", label: "Enable Alerts", helperText: "Evaluates expressions from in-cluster prometheus and exits 0 or 1", defaultValue: "False" },
       { key: "ALERTS_PATH", label: "Alerts Path", helperText: "Path to the alerts file to use when ENABLE_ALERTS is set", defaultValue: "config/alerts" },
       { key: "CHECK_CRITICAL_ALERTS", label: "Check Critical Alerts", helperText: "When enabled will check prometheus for critical alerts firing post chaos", defaultValue: "False" },
       { key: "RESILIENCY_RUN_MODE", label: "Resiliency Run Mode", helperText: "Resiliency scoring mode: standalone, detailed, or disabled", defaultValue: "standalone" },
       { key: "RESILIENCY_FILE", label: "Resiliency File", helperText: "Path to a YAML file containing SLO definitions", defaultValue: "config/alerts.yaml" },
-      { key: "ELASTIC_SERVER", label: "Elastic Server", helperText: "URL of the Elasticsearch instance to store telemetry data", defaultValue: "" },
-      { key: "ELASTIC_INDEX", label: "Elastic Index", helperText: "Elasticsearch index pattern to post results to", defaultValue: "" }
+      { key: "ENABLE_ES", label: "Enable ES", helperText: "Enable Elasticsearch integration", defaultValue: "False" },
+      { key: "ES_VERIFY_CERTS", label: "ES Verify Certs", helperText: "Verify SSL certificates when connecting to Elasticsearch", defaultValue: "True" },
+      { key: "ES_SERVER", label: "ES Server", helperText: "URL of the Elasticsearch instance", defaultValue: "" },
+      { key: "ES_PORT", label: "ES Port", helperText: "Port of the Elasticsearch instance", defaultValue: "" },
+      { key: "ES_USERNAME", label: "ES Username", helperText: "Username for Elasticsearch authentication", defaultValue: "" },
+      { key: "ES_PASSWORD", label: "ES Password", helperText: "Password for Elasticsearch authentication", defaultValue: "" },
+      { key: "ES_METRICS_INDEX", label: "ES Metrics Index", helperText: "Elasticsearch index for metrics data", defaultValue: "" },
+      { key: "ES_ALERTS_INDEX", label: "ES Alerts Index", helperText: "Elasticsearch index for alerts data", defaultValue: "" },
+      { key: "ES_TELEMETRY_INDEX", label: "ES Telemetry Index", helperText: "Elasticsearch index for telemetry data", defaultValue: "" },
+      { key: "ES_RUN_TAG", label: "ES Run Tag", helperText: "Tag to identify the run in Elasticsearch", defaultValue: "" }
     ]
   },
   {
@@ -657,7 +661,7 @@ export const globalParamsData = [
       { key: "KUBE_VIRT_FAILURES", label: "Kube Virt Failures", helperText: "If True, will only report when ssh connections fail to VMI", defaultValue: "" },
       { key: "KUBE_VIRT_DISCONNECTED", label: "Kube Virt Disconnected", helperText: "Use disconnected check by passing cluster API", defaultValue: "False" },
       { key: "KUBE_VIRT_NODE_NAME", label: "Kube Virt Node Name", helperText: "If set, will filter VMs to only track ones running on the specified node", defaultValue: "" },
-      { key: "KUBE_VIRT_EXIT_ON_FAIL", label: "Kube Virt Exit On Fail", helperText: "Fails run if VMs still have false status at end of run", defaultValue: "" },
+      { key: "KUBE_VIRT_EXIT_ON_FAILURE", label: "Kube Virt Exit On Failure", helperText: "Fails run if VMs still have false status at end of run", defaultValue: "False" },
       { key: "KUBE_VIRT_SSH_NODE", label: "Kube Virt SSH Node", helperText: "If set, will be a backup way to SSH to a node", defaultValue: "" }
     ]
   },
@@ -669,7 +673,7 @@ export const globalParamsData = [
       { key: "TELEMETRY_USERNAME", label: "Telemetry Username", helperText: "Telemetry service username", defaultValue: "redhat-chaos" },
       { key: "TELEMETRY_PASSWORD", label: "Telemetry Password", helperText: "Telemetry service password", defaultValue: "" },
       { key: "TELEMETRY_PROMETHEUS_BACKUP", label: "Telemetry Prometheus Backup", helperText: "Enables/disables prometheus data collection", defaultValue: "True" },
-      { key: "TELEMTRY_FULL_PROMETHEUS_BACKUP", label: "Telemetry Full Prometheus Backup", helperText: "If set to False only the /prometheus/wal folder will be downloaded", defaultValue: "False" },
+      { key: "TELEMETRY_FULL_PROMETHEUS_BACKUP", label: "Telemetry Full Prometheus Backup", helperText: "If set to False only the /prometheus/wal folder will be downloaded", defaultValue: "False" },
       { key: "TELEMETRY_BACKUP_THREADS", label: "Telemetry Backup Threads", helperText: "Number of telemetry download/upload threads", defaultValue: "5" },
       { key: "TELEMETRY_ARCHIVE_PATH", label: "Telemetry Archive Path", helperText: "Local path where the archive files will be temporarily stored", defaultValue: "/tmp" },
       { key: "TELEMETRY_MAX_RETRIES", label: "Telemetry Max Retries", helperText: "Maximum number of upload retries (if 0 will retry forever)", defaultValue: "0" },
@@ -677,7 +681,8 @@ export const globalParamsData = [
       { key: "TELEMETRY_GROUP", label: "Telemetry Group", helperText: "If set will archive the telemetry in the S3 bucket on a folder named after the value", defaultValue: "default" },
       { key: "TELEMETRY_ARCHIVE_SIZE", label: "Telemetry Archive Size", helperText: "The size of the prometheus data archive in KB", defaultValue: "1000" },
       { key: "TELEMETRY_LOGS_BACKUP", label: "Telemetry Logs Backup", helperText: "Logs backup to S3", defaultValue: "False" },
-      { key: "TELEMETRY_FILTER_PATTER", label: "Telemetry Filter Pattern", helperText: "Filter logs based on certain timestamp patterns", defaultValue: "" },
+      { key: "TELEMETRY_EVENTS_BACKUP", label: "Telemetry Events Backup", helperText: "Enables/disables events backup to S3", defaultValue: "False" },
+      { key: "TELEMETRY_FILTER_PATTERN", label: "Telemetry Filter Pattern", helperText: "Filter logs based on certain timestamp patterns", defaultValue: "" },
       { key: "TELEMETRY_CLI_PATH", label: "Telemetry CLI Path", helperText: "OC CLI path, if not specified will be searched in $PATH", defaultValue: "" }
     ]
   }

--- a/src/components/NewExperiment/index.jsx
+++ b/src/components/NewExperiment/index.jsx
@@ -71,7 +71,6 @@ const NewExperiment = () => {
       name_pattern: ".*",
       disruption_count: 1,
       kill_timeout: 180,
-      wait_timeout: 360,
       expected_pod_count: "",
       scenarioChecked: "pod-scenarios",
       name: "",

--- a/src/components/NewExperiment/index.jsx
+++ b/src/components/NewExperiment/index.jsx
@@ -7,6 +7,7 @@ import {
   Button,
   Card,
   CardBody,
+  ExpandableSection,
   Form,
   FormGroup,
   Grid,
@@ -24,7 +25,7 @@ import KubeconfigSelect from "@/components/molecules/KubeconfigSelect";
 import { TextButton } from "@/components/atoms/Buttons/Buttons";
 import API from "@/utils/axiosInstance";
 import { extractReplayBaseStem } from "@/utils/replayNaming";
-import { paramsList } from "./experimentFormData";
+import { paramsList, globalParamsData } from "./experimentFormData";
 import { setActiveGroupId } from "@/actions/authActions";
 import { showToast } from "@/actions/toastActions";
 import { startKraken, updateScenarioChecked } from "@/actions/newExperiment";
@@ -163,6 +164,25 @@ const NewExperiment = () => {
     },
   });
 
+  const initGlobalData = () => {
+    const defaults = {};
+    globalParamsData.forEach((cat) => {
+      cat.fields.forEach((field) => {
+        defaults[field.key] = field.defaultValue;
+      });
+    });
+    return defaults;
+  };
+
+  const [globalData, setGlobalData] = useState(initGlobalData());
+
+  const globalChangeHandler = (_event, value, key) => {
+    setGlobalData((prevState) => ({
+      ...prevState,
+      [key]: value,
+    }));
+  };
+
   useEffect(() => {
     if (replayAppliedRef.current) return;
     const replay = location.state?.replay;
@@ -189,12 +209,19 @@ const NewExperiment = () => {
     const stem = extractReplayBaseStem(stored.name);
     (async () => {
       try {
-        const { data } = await API.post("/past-runs/allocate-replay-name", {
+        const { data: replayResponse } = await API.post("/past-runs/allocate-replay-name", {
           baseStem: stem,
           groupId: targetGroupId || activeGroupId || undefined,
         });
-        const allocatedName = data?.name;
+        const allocatedName = replayResponse?.name;
         if (!allocatedName) throw new Error("No name returned");
+
+        if (stored.globalParams) {
+          setGlobalData(stored.globalParams);
+        } else {
+          setGlobalData(initGlobalData());
+        }
+
         setData((prev) => ({
           ...prev,
           [scenario]: {
@@ -267,6 +294,7 @@ const NewExperiment = () => {
     if (kubeconfigSelection && kubeconfigSelection !== "legacy") {
       payload = { ...payload, kubeconfigId: parseInt(kubeconfigSelection, 10) };
     }
+    payload.globalParams = globalData;
     return payload;
   };
 
@@ -464,6 +492,39 @@ const NewExperiment = () => {
                   </GridItem>
                 );
               })}
+
+            {/* Global Scenario Variables Collapsible Section */}
+            <GridItem span={12} className="new-experiment__global-section-wrapper pf-v5-u-mt-md">
+              <ExpandableSection toggleText="Global Scenario Variables" displaySize="large">
+                <Grid hasGutter className="pf-v5-u-mt-md">
+                  {globalParamsData.map((category) => (
+                    <GridItem span={12} key={category.category} className="new-experiment__global-category-item">
+                      <ExpandableSection toggleText={category.category}>
+                        <Grid hasGutter className="pf-v5-u-mt-md pf-v5-u-p-md" style={{ backgroundColor: "var(--pf-v5-global--BackgroundColor--light-100)", borderRadius: "4px" }}>
+                          {category.fields.map((field) => (
+                            <GridItem span={6} key={field.key}>
+                              <FormGroup
+                                label={field.label}
+                                fieldId={field.key}
+                                helperText={field.helperText}
+                              >
+                                <TextInput
+                                  type="text"
+                                  id={field.key}
+                                  name={field.key}
+                                  value={globalData[field.key] ?? ""}
+                                  onChange={(evt, val) => globalChangeHandler(evt, val, field.key)}
+                                />
+                              </FormGroup>
+                            </GridItem>
+                          ))}
+                        </Grid>
+                      </ExpandableSection>
+                    </GridItem>
+                  ))}
+                </Grid>
+              </ExpandableSection>
+            </GridItem>
           </Grid>
           <ActionGroup className="action-group-wrapper">
             <TextButton


### PR DESCRIPTION
### Summary 
This PR adds support for setting top-level global configuration parameters (such as Telemetry, Cerberus, Performance Monitoring, Health Checks, and Tunings) directly from the Run Kraken dashboard.These variables are shared across all Krkn-Hub scenarios and are injected into the scenario execution containers at run time.
<img width="1881" height="921" alt="Screenshot 2026-06-02 225038" src="https://github.com/user-attachments/assets/5ac1b2f3-d2b3-4cea-a85f-de9ee6b5ba5b" />
<img width="1329" height="801" alt="Screenshot 2026-06-02 225057" src="https://github.com/user-attachments/assets/d496315d-dc03-46b1-8dd7-4ce179522684" />
<img width="1717" height="909" alt="Screenshot 2026-06-02 225115" src="https://github.com/user-attachments/assets/b872f521-9cfb-4d9f-9cea-006e3252be18" />

Removed Wait Timeout from Pod scenario Parameter --
<img width="1896" height="935" alt="image" src="https://github.com/user-attachments/assets/8e09c76f-a2c4-4b7c-9397-d07d8dcf7666" />


Closes : #88 
